### PR TITLE
fix(soccer-stats-ui): fix team list not updating after creating a team

### DIFF
--- a/apps/soccer-stats/ui/src/app/pages/create-team.page.tsx
+++ b/apps/soccer-stats/ui/src/app/pages/create-team.page.tsx
@@ -41,7 +41,13 @@ export const CreateTeamPage = () => {
       onError: (err) => {
         setError(err.message);
       },
-      refetchQueries: ['GetMyTeamsForList', 'DebugGetTeams'],
+      update: (cache) => {
+        // Evict teams from cache to force refetch when returning to teams list
+        // String-based refetchQueries don't work reliably with TypedDocumentNode
+        cache.evict({ fieldName: 'teams' });
+        cache.evict({ fieldName: 'myTeams' });
+        cache.gc();
+      },
     }
   );
 


### PR DESCRIPTION
## Summary
- Fix Apollo cache invalidation issue where newly created teams don't appear in the teams list
- Replace string-based `refetchQueries` with `cache.evict()` for reliable cache clearing

## Problem
When creating a team, the user is redirected to the team details page. When navigating back to the teams list, the newly created team wasn't showing because:

1. String-based `refetchQueries` (`['GetMyTeamsForList', 'DebugGetTeams']`) don't work reliably with GraphQL Code Generator's `TypedDocumentNode` pattern
2. When navigating away from the teams list, those queries are unmounted and no longer active in Apollo's query registry

## Solution
Use `cache.evict()` to clear the `teams` and `myTeams` fields from Apollo's cache, which forces a refetch when the user returns to the teams list.

## Test plan
- [ ] Create a new team
- [ ] Verify redirect to team details page works
- [ ] Navigate back to teams list
- [ ] Verify the newly created team appears in the list

🤖 Generated with [Claude Code](https://claude.com/claude-code)