### PR TITLE
fix(soccer-stats): fix duplicate position assignment and add 3-4-1 formation

### DIFF
--- a/apps/soccer-stats/ui/src/app/constants/positions.ts
+++ b/apps/soccer-stats/ui/src/app/constants/positions.ts
@@ -1,20 +1,98 @@
 // Formation positions for soccer
+// Traditional numbers based on classic 2-3-5 / 4-4-2 numbering conventions
 export const POSITIONS = {
-  GK: { code: 'GK', name: 'Goalkeeper', category: 'defense' },
-  LB: { code: 'LB', name: 'Left Back', category: 'defense' },
-  CB: { code: 'CB', name: 'Center Back', category: 'defense' },
-  RB: { code: 'RB', name: 'Right Back', category: 'defense' },
-  LWB: { code: 'LWB', name: 'Left Wing Back', category: 'defense' },
-  RWB: { code: 'RWB', name: 'Right Wing Back', category: 'defense' },
-  CDM: { code: 'CDM', name: 'Defensive Midfielder', category: 'midfield' },
-  CM: { code: 'CM', name: 'Central Midfielder', category: 'midfield' },
-  CAM: { code: 'CAM', name: 'Attacking Midfielder', category: 'midfield' },
-  LM: { code: 'LM', name: 'Left Midfielder', category: 'midfield' },
-  RM: { code: 'RM', name: 'Right Midfielder', category: 'midfield' },
-  LW: { code: 'LW', name: 'Left Wing', category: 'attack' },
-  RW: { code: 'RW', name: 'Right Wing', category: 'attack' },
-  CF: { code: 'CF', name: 'Center Forward', category: 'attack' },
-  ST: { code: 'ST', name: 'Striker', category: 'attack' },
+  // Goalkeeper
+  GK: {
+    code: 'GK',
+    name: 'Goalkeeper',
+    category: 'defense',
+    traditionalNumber: 1,
+  },
+
+  // Defenders (2-5)
+  RB: {
+    code: 'RB',
+    name: 'Right Back',
+    category: 'defense',
+    traditionalNumber: 2,
+  },
+  LB: {
+    code: 'LB',
+    name: 'Left Back',
+    category: 'defense',
+    traditionalNumber: 3,
+  },
+  CB: {
+    code: 'CB',
+    name: 'Center Back',
+    category: 'defense',
+    traditionalNumber: 4,
+  }, // or 5
+  RWB: {
+    code: 'RWB',
+    name: 'Right Wing Back',
+    category: 'defense',
+    traditionalNumber: 2,
+  },
+  LWB: {
+    code: 'LWB',
+    name: 'Left Wing Back',
+    category: 'defense',
+    traditionalNumber: 3,
+  },
+
+  // Midfielders (4, 6, 8, 10)
+  CDM: {
+    code: 'CDM',
+    name: 'Defensive Midfielder',
+    category: 'midfield',
+    traditionalNumber: 6,
+  },
+  CM: {
+    code: 'CM',
+    name: 'Central Midfielder',
+    category: 'midfield',
+    traditionalNumber: 8,
+  },
+  CAM: {
+    code: 'CAM',
+    name: 'Attacking Midfielder',
+    category: 'midfield',
+    traditionalNumber: 10,
+  },
+  LM: {
+    code: 'LM',
+    name: 'Left Midfielder',
+    category: 'midfield',
+    traditionalNumber: 11,
+  },
+  RM: {
+    code: 'RM',
+    name: 'Right Midfielder',
+    category: 'midfield',
+    traditionalNumber: 7,
+  },
+
+  // Attackers (7, 9, 10, 11)
+  RW: {
+    code: 'RW',
+    name: 'Right Wing',
+    category: 'attack',
+    traditionalNumber: 7,
+  },
+  LW: {
+    code: 'LW',
+    name: 'Left Wing',
+    category: 'attack',
+    traditionalNumber: 11,
+  },
+  CF: {
+    code: 'CF',
+    name: 'Center Forward',
+    category: 'attack',
+    traditionalNumber: 10,
+  },
+  ST: { code: 'ST', name: 'Striker', category: 'attack', traditionalNumber: 9 },
 } as const;
 
 export type PositionCode = keyof typeof POSITIONS;
@@ -110,6 +188,22 @@ export const FORMATIONS_9V9: Formation[] = [
       { position: 'RM', x: 80, y: 50 },
       { position: 'ST', x: 35, y: 75 },
       { position: 'ST', x: 65, y: 75 },
+    ],
+  },
+  {
+    name: '3-4-1',
+    code: '3-4-1',
+    playersPerTeam: 9,
+    positions: [
+      { position: 'GK', x: 50, y: 5 },
+      { position: 'LB', x: 20, y: 25 },
+      { position: 'CB', x: 50, y: 20 },
+      { position: 'RB', x: 80, y: 25 },
+      { position: 'LM', x: 15, y: 50 },
+      { position: 'CM', x: 38, y: 45 },
+      { position: 'CM', x: 62, y: 45 },
+      { position: 'RM', x: 85, y: 50 },
+      { position: 'ST', x: 50, y: 75 },
     ],
   },
   {


### PR DESCRIPTION
## Summary
- **Fix lineup position assignment bug**: When formations have multiple slots with the same position code (e.g., two CBs), players are now correctly distributed instead of only showing one player
- **Add 3-4-1 formation for 9v9**: A more defensive variant with 3 defenders, 4 midfielders, and 1 striker
- **Add traditional jersey numbers to position definitions**: Following classic soccer numbering conventions (GK=1, RB=2, LB=3, CB=4, etc.)

## Changes

### 1. Fix duplicate position assignment (`field-lineup.presentation.tsx`)
**Problem:** The component used a `Map<string, LineupPlayer>` keyed by position code. When two slots shared the same position (like "CB"), the second player overwrote the first.

**Solution:** Refactored to:
1. Group players by position code into arrays
2. Use `useMemo` to precompute assignments
3. Sequentially assign players to formation slots with matching positions

### 2. Add 3-4-1 formation (`positions.ts`)
New formation for 9v9 games:
- GK at center
- 3 defenders: LB, CB, RB
- 4 midfielders: LM, CM, CM, RM
- 1 striker: ST (central)

### 3. Add traditional jersey numbers (`positions.ts`)
Each position now includes a `traditionalNumber` based on classic soccer conventions:
| # | Position | # | Position |
|---|----------|---|----------|
| 1 | GK | 7 | RW/RM |
| 2 | RB/RWB | 8 | CM |
| 3 | LB/LWB | 9 | ST |
| 4 | CB | 10 | CAM/CF |
| 6 | CDM | 11 | LW/LM |

## Test plan
- [ ] Verify 4-4-2 formation shows both CBs and both STs correctly
- [ ] Verify 3-4-1 appears in 9v9 formation selector
- [ ] Verify player assignment works correctly in new 3-4-1 formation

🤖 Generated with [Claude Code](https://claude.com/claude-code)