### PR TITLE
refactor(soccer-stats): connect directly to Railway from Vercel

### DIFF
--- a/apps/soccer-stats/ui/project.json
+++ b/apps/soccer-stats/ui/project.json
@@ -130,16 +130,7 @@
         "outputPath": "dist/apps/soccer-stats/ui",
         "projectName": "soccer-stats",
         "org": "team_10d4zK2wwm7wqaGMq7zgua8w",
-        "projectId": "prj_lkXNHKu9yeggBRZy4AkPGV4ajGET",
-        "rewrites": [
-          {
-            "source": "/api/:path*",
-            "destination": "https://soccer-stats.up.railway.app/api/:path*",
-            "headers": {
-              "Cache-Control": "no-cache, no-store, must-revalidate"
-            }
-          }
-        ]
+        "projectId": "prj_lkXNHKu9yeggBRZy4AkPGV4ajGET"
       },
       "configurations": {
         "production": {


### PR DESCRIPTION
## Summary

Remove Vercel rewrite proxy and connect both HTTP and WebSocket requests directly to Railway when running on Vercel deployments.

### Before (hybrid routing)
```
HTTP  → Vercel → rewrite → Railway  (extra hop)
WS    → Direct to Railway
```

### After (direct routing)
```
HTTP  → Direct to Railway
WS    → Direct to Railway
```

### Benefits
- **Simpler architecture** - One connection path instead of two
- **Reduced latency** - No extra hop through Vercel for HTTP requests
- **Easier debugging** - No proxy in the middle
- **Consistent behavior** - HTTP and WebSocket use the same routing logic

### Changes
- `apollo-client.ts`: Add `isVercelDeployment()` helper and `getHttpUrl()` function for runtime detection
- `project.json`: Remove `rewrites` configuration from deploy target

### Why this works
CORS is already configured on Railway (`FRONTEND_URL` includes Vercel domains), which was required for WebSocket connections. Removing the rewrite doesn't require backend changes.

## Test plan

- [ ] Verify HTTP queries work on Vercel preview deployment
- [ ] Verify WebSocket subscriptions work on Vercel preview deployment
- [ ] Verify local development still uses Vite proxy

🤖 Generated with [Claude Code](https://claude.com/claude-code)