### PR TITLE
fix(soccer-stats): improve field lineup view and document cache invalidation

### DIFF
--- a/apps/soccer-stats/ui-infra/README.md
+++ b/apps/soccer-stats/ui-infra/README.md
@@ -55,8 +55,25 @@ pnpm nx preview soccer-stats-ui-infra
 
 ## Outputs
 
-- `cloudfrontUrl` - CloudFront distribution URL (https://xxx.cloudfront.net)
+- `websiteUrl` - CloudFront distribution URL (https://xxx.cloudfront.net)
+- `distributionId` - CloudFront distribution ID
 - `bucketName` - S3 bucket name for static assets
+
+## Cache Invalidation
+
+After deploying new content, CloudFront may serve stale cached files. To force CloudFront to fetch fresh content from S3, run a cache invalidation:
+
+```bash
+# Get the distribution ID from Pulumi outputs
+pnpm nx up soccer-stats-ui-infra --stack dev 2>/dev/null | grep distributionId
+
+# Invalidate all cached files
+aws cloudfront create-invalidation \
+  --distribution-id <DISTRIBUTION_ID> \
+  --paths "/*"
+```
+
+**Note:** Cache invalidation is optional. CloudFront will eventually serve fresh content when the cache TTL expires. Use invalidation when you need immediate updates.
 
 ## Related
 

--- a/apps/soccer-stats/ui-infra/pulumi.ts
+++ b/apps/soccer-stats/ui-infra/pulumi.ts
@@ -3,7 +3,6 @@ import path from 'path';
 import * as pulumi from '@pulumi/pulumi';
 import * as aws from '@pulumi/aws';
 import * as synced from '@pulumi/synced-folder';
-import * as command from '@pulumi/command';
 import { workspaceRoot } from '@nx/devkit';
 
 import { getSharedInfraStackReference } from './stack-reference';
@@ -225,24 +224,6 @@ const syncedFolder = new synced.S3BucketFolder(`${namePrefix}-sync`, {
 });
 
 // =============================================================================
-// CloudFront Invalidation (on deployment)
-// =============================================================================
-// Create an invalidation after syncing new files to bust the CDN cache
-// Uses AWS CLI to create invalidation - runs after S3 sync completes
-const cacheInvalidation = new command.local.Command(
-  `${namePrefix}-cache-invalidation`,
-  {
-    create: pulumi.interpolate`aws cloudfront create-invalidation --distribution-id ${distribution.id} --paths "/*"`,
-    // Re-run invalidation on every deployment by using a timestamp trigger
-    triggers: [Date.now().toString()],
-  },
-  {
-    // Only run after files are synced to S3
-    dependsOn: [syncedFolder],
-  },
-);
-
-// =============================================================================
 // Exports
 // =============================================================================
 export const bucketName = bucket.bucket;
@@ -266,6 +247,3 @@ export const apiEndpoint = customDomain
 export const albDirectUrl = pulumi.interpolate`http://${albDnsName}`;
 
 export const environment = stack;
-
-// Cache invalidation output (shows the AWS CLI response)
-export const cacheInvalidationOutput = cacheInvalidation.stdout;

--- a/package.json
+++ b/package.json
@@ -168,7 +168,6 @@
     "@nestjs/graphql": "^13.1.0",
     "@nestjs/platform-express": "^11.0.0",
     "@nestjs/typeorm": "^10.0.0",
-    "@pulumi/command": "^1.1.3",
     "@react-email/body": "0.0.1",
     "@react-email/button": "0.0.5",
     "@react-email/html": "0.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,9 +70,6 @@ importers:
       '@nestjs/typeorm':
         specifier: ^10.0.0
         version: 10.0.2(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@11.1.6)(reflect-metadata@0.1.14)(rxjs@7.8.1)(typeorm@0.3.25(babel-plugin-macros@3.1.0)(pg@8.16.3)(reflect-metadata@0.1.14)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@types/node@20.19.9)(typescript@5.9.3)))
-      '@pulumi/command':
-        specifier: ^1.1.3
-        version: 1.1.3(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@types/node@20.19.9)(typescript@5.9.3))(typescript@5.9.3)
       '@react-email/body':
         specifier: 0.0.1
         version: 0.0.1
@@ -7578,12 +7575,6 @@ packages:
     resolution:
       {
         integrity: sha512-2vT0T3MF0Nj9ZP+pGLDSSJ5zTPOT42fPMNddUkPmKsJJ8Zyhjw8+2FKtHJAPPs4oeUVI3z5Zp3qOECa0EtqX6w==,
-      }
-
-  '@pulumi/command@1.1.3':
-    resolution:
-      {
-        integrity: sha512-eBzGE/BQlxMNcxrrA62N4cLaHdL0xDSRACXxB0Hjc4rJG60vhpDVO130xxb4x3cZ7HT1kvjS4KuuoH8R5JRbIQ==,
       }
 
   '@pulumi/docker-build@0.0.14':
@@ -37472,15 +37463,6 @@ snapshots:
       mime: 2.6.0
     transitivePeerDependencies:
       - aws-crt
-      - bluebird
-      - supports-color
-      - ts-node
-      - typescript
-
-  '@pulumi/command@1.1.3(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@types/node@20.19.9)(typescript@5.9.3))(typescript@5.9.3)':
-    dependencies:
-      '@pulumi/pulumi': 3.214.1(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@types/node@20.19.9)(typescript@5.9.3))(typescript@5.9.3)
-    transitivePeerDependencies:
       - bluebird
       - supports-color
       - ts-node


### PR DESCRIPTION
## Summary

- **Field lineup view improvements**: Refactored from full-field to 3/4 field perspective with proper coordinate transformations (GK at bottom, strikers at top)
- **Cache invalidation documentation**: Removed automatic CloudFront invalidation from Pulumi in favor of manual command (simpler, avoids deployment failures)

## Changes

### Field Lineup Component
- Changed viewBox from 0-150 (full field) to 0-125 (3/4 field view)
- Added proper Y-axis transformation: GK (y=5) at bottom, forwards at top
- Added X-axis transformation for away team coordinate flipping
- Cleaned up SVG field markings for 3/4 view

### Infrastructure
- Removed `@pulumi/command` dependency
- Added "Cache Invalidation" section to README with manual AWS CLI command
- Operators can run invalidation manually when needed rather than on every deploy

## Test plan

- [ ] Verify field lineup displays correctly for home team (GK at bottom)
- [ ] Verify field lineup displays correctly for away team (coordinates flipped)
- [ ] Verify Pulumi deployment succeeds without cache invalidation step
- [ ] Test manual cache invalidation command from README

🤖 Generated with [Claude Code](https://claude.ai/code)