### PR TITLE
feat(soccer-stats-ui): default opponent to unmanaged team in game creation

### DIFF
--- a/apps/soccer-stats/ui/src/app/pages/create-game.page.tsx
+++ b/apps/soccer-stats/ui/src/app/pages/create-game.page.tsx
@@ -127,17 +127,6 @@ export const CreateGamePage = () => {
             },
           });
 
-          // Check for GraphQL errors in the result
-          if (opponentResult.errors && opponentResult.errors.length > 0) {
-            const errorMessage = opponentResult.errors
-              .map((e) => e.message)
-              .join(', ');
-            setError(
-              `Could not create opponent "${gameForm.opponentName}": ${errorMessage}`,
-            );
-            return;
-          }
-
           awayTeamId = opponentResult.data?.findOrCreateUnmanagedTeam.id ?? '';
 
           if (!awayTeamId) {
@@ -147,8 +136,11 @@ export const CreateGamePage = () => {
             return;
           }
         } catch (err) {
-          const message = err instanceof Error ? err.message : 'Network error';
-          setError(`Failed to create opponent team: ${message}`);
+          // Catches both network errors and GraphQL errors
+          const message = err instanceof Error ? err.message : 'Unknown error';
+          setError(
+            `Failed to create opponent "${gameForm.opponentName}": ${message}`,
+          );
           return;
         }
       }


### PR DESCRIPTION
## Summary
- Changed game scheduling flow so opponent team defaults to creating an unmanaged team by name
- Added toggle option to select a managed team instead (for scrimmages between user's own teams)
- Uses `FIND_OR_CREATE_UNMANAGED_TEAM` mutation for automatic deduplication by name

## Test plan
- [ ] Navigate to `/games/new` and verify home team dropdown shows only managed teams
- [ ] Enter an opponent name in the text input and create a game - verify unmanaged team is created
- [ ] Create another game with the same opponent name - verify it reuses the existing team (no duplicate)
- [ ] Click "Or select from your teams" toggle and verify managed teams dropdown appears
- [ ] Select a managed team as opponent and create game - verify scrimmage works

🤖 Generated with [Claude Code](https://claude.com/claude-code)