### PR TITLE
perf(soccer-stats-api): batch database saves instead of sequential inserts

### DIFF
--- a/apps/soccer-stats/api/src/modules/game-events/services/substitution.service.ts
+++ b/apps/soccer-stats/api/src/modules/game-events/services/substitution.service.ts
@@ -381,10 +381,9 @@ export class SubstitutionService {
       throw new NotFoundException(`GameTeam ${gameTeamId} not found`);
     }
 
-    const events: GameEvent[] = [];
-
-    for (const player of lineup.currentOnField) {
-      const subOutEvent = this.gameEventsRepository.create({
+    // Batch create all SUB_OUT events
+    const subOutEventsToCreate = lineup.currentOnField.map((player) =>
+      this.gameEventsRepository.create({
         gameId: gameTeam.gameId,
         gameTeamId,
         eventTypeId: subOutType.id,
@@ -397,13 +396,14 @@ export class SubstitutionService {
         gameSecond,
         parentEventId,
         period,
-      });
+      }),
+    );
 
-      const savedEvent = await this.gameEventsRepository.save(subOutEvent);
-      events.push(savedEvent);
-    }
+    // Single batch insert instead of N individual inserts
+    const savedEvents =
+      await this.gameEventsRepository.save(subOutEventsToCreate);
 
-    return events;
+    return savedEvents;
   }
 
   /**


### PR DESCRIPTION
## Summary

Replace sequential `await` loops with batch save operations to reduce database round-trips during period transitions.

### Changes

- **startPeriod()**: batch SUB_IN inserts (11 queries → 1)
- **endPeriod()**: batch SUB_OUT inserts (11 queries → 1)
- **setSecondHalfLineup()**: batch SUB_IN inserts (11 queries → 1)
- **createSubstitutionOutForAllOnField()**: batch SUB_OUT inserts (N queries → 1)
- Use `Promise.all()` for parallel PubSub publishing

### Performance Impact

For a typical 11-player team:
- **Before**: ~44 database queries per game (11 players × 4 transitions)
- **After**: ~4 database queries per game

### Files Changed

- `apps/soccer-stats/api/src/modules/game-events/services/period.service.ts`
- `apps/soccer-stats/api/src/modules/game-events/services/substitution.service.ts`

## Test plan

- [x] All 107 unit tests pass
- [x] Lint passes
- [ ] Manual test: start game, transition through halftime, end game - verify events created correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)