### PR TITLE
docs: update CLAUDE.md and README.md for consistency with codebase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,14 +8,14 @@ Garage is an Nx monorepo containing multiple full-stack applications and shared 
 
 **Key Technologies:**
 
-- **Build System:** Nx 21.4.1 monorepo with intelligent caching
+- **Build System:** Nx 22.3.3 monorepo with intelligent caching
 - **Package Manager:** pnpm (specified in package.json packageManager field)
 - **Node Version:** v24.4.1 (see .nvmrc)
-- **Frontend:** React 18.3.1 with Vite, Angular 20.1.8
-- **Backend:** NestJS 11.0.0, Express 4.21.2
+- **Frontend:** React 18.3.1 with Vite, Angular 21.0.6
+- **Backend:** NestJS 11.0.0, Express 5.0.0
 - **Database:** PostgreSQL 15 with TypeORM 0.3.17
 - **GraphQL:** Apollo Server/Client with GraphQL Code Generator
-- **Testing:** Vitest 3.2.4, Jest 30.0.5, Playwright
+- **Testing:** Vitest 4.0.9, Jest 30.0.5, Playwright
 - **Styling:** Tailwind CSS 3.4.3 (primary styling approach)
 
 ## Common Development Commands
@@ -140,7 +140,7 @@ pnpm nx serve:dev soccer-stats-api
 - PostgreSQL: `localhost:5432` (user/pass: postgres/postgres, db: soccer_stats)
 - Adminer (web UI): `http://localhost:8080`
 
-**Database Initialization:** SQL scripts in `apps/soccer-stats-api/database/init/` run automatically on first container start.
+**Database Initialization:** SQL scripts in `apps/soccer-stats/api/database/init/` run automatically on first container start.
 
 ### Database Migrations (soccer-stats-api)
 
@@ -193,7 +193,9 @@ This is an Nx monorepo with apps and libraries organized by domain:
 
 ```
 apps/
-├── auth/api/              # Authentication services (Express & NestJS variants)
+├── auth/api/              # Authentication services
+│   ├── express/          # Express variant
+│   └── nest/             # NestJS variant
 ├── campsite-watcher/      # Campsite availability monitoring service
 ├── campsite-watcher-lambda/ # AWS Lambda version
 ├── chore-board/           # Kanban-style chore tracking app
@@ -203,8 +205,11 @@ apps/
 ├── soccer-stats/          # Soccer statistics tracker (primary app)
 │   ├── api/              # NestJS GraphQL backend
 │   ├── api-e2e/          # E2E tests for API
+│   ├── api-infra/        # API infrastructure (Pulumi)
+│   ├── docs/             # Documentation
 │   ├── ui/               # React/Vite frontend
-│   └── ui-e2e/           # E2E tests for UI
+│   ├── ui-e2e/           # E2E tests for UI
+│   └── ui-infra/         # UI infrastructure (Pulumi)
 └── nx-kaniko/             # Docker build utilities
 
 libs/
@@ -214,7 +219,9 @@ libs/
 ├── ng/lib-example/        # Shared Angular components
 ├── soccer-stats/          # Soccer stats shared libraries
 │   ├── graphql-codegen/  # Generated GraphQL types (non-buildable)
-│   └── ui-components/    # Shared React presentation components (buildable)
+│   ├── infra/            # Shared infrastructure utilities
+│   ├── ui-components/    # Shared React presentation components (buildable)
+│   └── utils/            # Shared utility functions
 └── wordle/core/           # Wordle game logic
 ```
 
@@ -251,12 +258,15 @@ entities/                  # TypeORM database entities
 
 modules/                   # Feature modules (NestJS + TypeGraphQL)
 ├── auth/                  # Authentication & authorization
-├── users/                 # User management
-├── teams/                 # Team CRUD & relationships
-├── players/               # Player management
 ├── coaches/               # Coach assignments
+├── dataloaders/           # DataLoader infrastructure for N+1 prevention
+├── event-types/           # Event type definitions
+├── game-events/           # Game event tracking & subscriptions
+├── game-formats/          # Game format configurations
 ├── games/                 # Game tracking
-└── game-formats/          # Game format configurations
+├── players/               # Player management
+├── teams/                 # Team CRUD & relationships
+└── users/                 # User management
 ```
 
 **Frontend Structure (`apps/soccer-stats/ui/src/app/`):**
@@ -407,6 +417,10 @@ TypeScript path aliases are defined in `tsconfig.base.json`:
 "@garage/campsite-watcher/core"           → libs/campsite-watcher/core/src/index.ts
 "@garage/campsite-watcher/recreation-gov" → libs/campsite-watcher/recreation-gov/src/index.ts
 "@garage/ng/lib-example"                  → libs/ng/lib-example/src/index.ts
+"@garage/soccer-stats/graphql-codegen"    → libs/soccer-stats/graphql-codegen/src/index.ts
+"@garage/soccer-stats/infra"              → libs/soccer-stats/infra/src/index.ts
+"@garage/soccer-stats/ui-components"      → libs/soccer-stats/ui-components/src/index.ts
+"@garage/soccer-stats/utils"              → libs/soccer-stats/utils/src/index.ts
 "@garage/wordle/core"                     → libs/wordle/core/src/index.ts
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,90 +1,81 @@
 # Garage
 
-This project was generated using [Nx](https://nx.dev).
+An Nx monorepo containing multiple full-stack applications and shared libraries. The workspace includes React/Angular frontends, NestJS/Express backends, AWS Lambda functions, and shared TypeScript libraries.
 
 <p style="text-align: center;"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx-logo.png" width="450"></p>
 
-🔎 **Smart, Fast and Extensible Build System**
+For detailed development guidelines, see **[CLAUDE.md](./CLAUDE.md)**.
 
-## Adding capabilities to your workspace
+## Quick Start
 
-Nx supports many plugins which add capabilities for developing different types of applications and different tools.
+```bash
+# Use Node.js v24.4.1
+nvm use  # or fnm use
 
-These capabilities include generating applications, libraries, etc as well as the devtools to test, and build projects as well.
+# Enable pnpm
+corepack enable
 
-Below are our core plugins:
+# Install dependencies
+pnpm install --frozen-lockfile --ignore-scripts
+```
 
-- [React](https://reactjs.org)
-  - `pnpm add --save-dev @nx/react`
-- Web (no framework frontends)
-  - `pnpm add --save-dev @nx/web`
-- [Angular](https://angular.io)
-  - `pnpm add --save-dev @nx/angular`
-- [Nest](https://nestjs.com)
-  - `pnpm add --save-dev @nx/nest`
-- [Express](https://expressjs.com)
-  - `pnpm add --save-dev @nx/express`
-- [Node](https://nodejs.org)
-  - `pnpm add --save-dev @nx/node`
+## Key Technologies
 
-There are also many [community plugins](https://nx.dev/community) you could add.
+- **Build System:** Nx 22.3.3
+- **Package Manager:** pnpm
+- **Frontend:** React 18.3.1, Angular 21.0.6
+- **Backend:** NestJS 11.0.0, Express 5.0.0
+- **Database:** PostgreSQL with TypeORM
+- **GraphQL:** Apollo Server/Client
+- **Testing:** Vitest, Jest, Playwright
 
-## Generate an application
+## Common Commands
 
-Run `nx g @nx/react:app my-app` to generate an application.
+```bash
+# Serve applications
+pnpm nx serve soccer-stats-ui    # Full stack soccer stats (starts API too)
+pnpm nx serve chore-board-ui     # Chore board app
+pnpm nx serve ng-example         # Angular example
 
-> You can use any of the plugins above to generate applications as well.
+# Build, test, and lint
+pnpm nx build <project-name>
+pnpm nx test <project-name>
+pnpm nx lint <project-name>
 
-When using Nx, you can create multiple applications and libraries in the same workspace.
+# Run affected commands
+pnpm nx affected -t test
+pnpm nx affected -t build
+pnpm nx affected -t lint
+```
 
-## Generate a library
+## Project Structure
 
-Run `nx g @nx/react:lib my-lib` to generate a library.
+```
+apps/
+├── soccer-stats/          # Primary app: Soccer statistics tracker
+├── chore-board/           # Kanban-style chore tracking
+├── auth/api/              # Authentication services
+├── campsite-watcher/      # Campsite availability monitoring
+└── ng/example/            # Angular example app
 
-> You can also use any of the plugins above to generate libraries as well.
+libs/
+├── soccer-stats/          # Soccer stats shared libraries
+├── campsite-watcher/      # Campsite watcher libraries
+├── ng/lib-example/        # Angular shared components
+└── wordle/core/           # Wordle game logic
+```
 
-Libraries are shareable across libraries and applications. They can be imported from `@garage/mylib`.
+## Visualize the Workspace
 
-## Development server
+```bash
+pnpm nx graph
+```
 
-Run `nx serve my-app` for a dev server. Navigate to http://localhost:4200/. The app will automatically reload if you change any of the source files.
+## Documentation
 
-## Code scaffolding
+- **[CLAUDE.md](./CLAUDE.md)** - Comprehensive development guidelines
+- **[Nx Documentation](https://nx.dev)** - Nx framework docs
 
-Run `nx g @nx/react:component my-component --project=my-app` to generate a new component.
+## Nx Cloud
 
-## Build
-
-Run `nx build my-app` to build the project. The build artifacts will be stored in the `dist/` directory. Use the `--prod` flag for a production build.
-
-## Running unit tests
-
-Run `nx test my-app` to execute the unit tests via [Jest](https://jestjs.io).
-
-Run `nx affected:test` to execute the unit tests affected by a change.
-
-## Running end-to-end tests
-
-Run `ng e2e my-app` to execute the end-to-end tests via [Cypress](https://www.cypress.io).
-
-Run `nx affected:e2e` to execute the end-to-end tests affected by a change.
-
-## Understand your workspace
-
-Run `nx graph` to see a diagram of the dependencies of your projects.
-
-## Further help
-
-Visit the [Nx Documentation](https://nx.dev) to learn more.
-
-## ☁ Nx Cloud
-
-### Distributed Computation Caching & Distributed Task Execution
-
-<p style="text-align: center;"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx-cloud-card.png"></p>
-
-Nx Cloud pairs with Nx in order to enable you to build and test code more rapidly, by up to 10 times. Even teams that are new to Nx can connect to Nx Cloud and start saving time instantly.
-
-Teams using Nx gain the advantage of building full-stack applications with their preferred framework alongside Nx’s advanced code generation and project dependency graph, plus a unified experience for both frontend and backend developers.
-
-Visit [Nx Cloud](https://nx.app/) to learn more.
+This workspace uses Nx Cloud for distributed caching. Visit [Nx Cloud](https://nx.app/) to learn more.


### PR DESCRIPTION
- Update version numbers: Nx 22.3.3, Angular 21.0.6, Express 5.0.0, Vitest 4.0.9
- Fix auth directory structure to show express/nest subdirectories
- Add missing soccer-stats directories: api-infra, ui-infra, docs
- Add missing libs: soccer-stats/infra, soccer-stats/utils
- Add missing path aliases for soccer-stats libraries
- Add missing modules: dataloaders, event-types, game-events
- Fix database init path from apps/soccer-stats-api to apps/soccer-stats/api
- Modernize README.md with accurate project info and pnpm commands
- Update affected commands to use modern syntax (-t flag)
- Remove outdated Cypress reference in favor of Playwright

https://claude.ai/code/session_012HtzqN7YZbRqLJGfMK9YYe