### PR TITLE
fix(soccer-stats): clean up CD reporting and health checks

### DIFF
--- a/.github/workflows/deploy-soccer-stats.yml
+++ b/.github/workflows/deploy-soccer-stats.yml
@@ -10,6 +10,7 @@ on:
 permissions:
   id-token: write # OIDC token for assuming the AWS CD role
   contents: read
+  deployments: write
 
 # Never run two pulumi ups against the same stacks concurrently
 concurrency:
@@ -21,6 +22,7 @@ env:
   NX_LOAD_DOT_ENV_FILES: 'false'
   NX_TUI: 'false'
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+  SOCCER_STATS_SITE_URL: https://d26g1hjb51pz2g.cloudfront.net
 
 jobs:
   deploy:
@@ -73,7 +75,7 @@ jobs:
       - name: Verify deployment health
         run: |
           for i in $(seq 1 20); do
-            STATUS=$(curl -s -o /dev/null -w '%{http_code}' --max-time 30 https://d26g1hjb51pz2g.cloudfront.net/api/health || true)
+            STATUS=$(curl -s -o /dev/null -w '%{http_code}' --max-time 30 "$SOCCER_STATS_SITE_URL/api/health" || true)
             if [ "$STATUS" = "200" ]; then
               echo "Health check passed"
               exit 0
@@ -83,3 +85,44 @@ jobs:
           done
           echo "Health check failed after 5 minutes"
           exit 1
+
+      - name: Record GitHub deployment
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cat > deployment.json <<JSON
+          {
+            "ref": "$GITHUB_SHA",
+            "environment": "soccer-stats-production",
+            "auto_merge": false,
+            "required_contexts": [],
+            "production_environment": true,
+            "description": "Soccer Stats production deployment"
+          }
+          JSON
+
+          DEPLOYMENT_ID=$(gh api \
+            --method POST \
+            "/repos/$GITHUB_REPOSITORY/deployments" \
+            --input deployment.json \
+            --jq '.id')
+
+          gh api \
+            --method POST \
+            "/repos/$GITHUB_REPOSITORY/deployments/$DEPLOYMENT_ID/statuses" \
+            -f state="success" \
+            -f environment="soccer-stats-production" \
+            -f environment_url="$SOCCER_STATS_SITE_URL" \
+            -f target_url="$SOCCER_STATS_SITE_URL" \
+            -f log_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+            -f description="Soccer Stats deployment verified healthy"
+
+      - name: Deployment summary
+        run: |
+          {
+            echo "## Soccer Stats deployment"
+            echo ""
+            echo "- URL: $SOCCER_STATS_SITE_URL"
+            echo "- Health: $SOCCER_STATS_SITE_URL/api/health"
+            echo "- GraphQL: $SOCCER_STATS_SITE_URL/api/graphql"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,17 +51,8 @@ jobs:
       - run: pnpm nx affected --target=lint --parallel --max-parallel=3
       - run: pnpm nx affected --target=test --parallel --max-parallel=2
       - run: pnpm nx affected --target=build --parallel --max-parallel=3
-      # Preview deployment on PRs
-      - name: Deploy (Preview)
-        if: ${{ github.event_name == 'pull_request' }}
-        run: pnpm nx affected --target=deploy --configuration=preview
-        env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-      # Production deployment on trunk
-      - name: Deploy (Production)
-        if: ${{ github.event_name != 'pull_request' }}
-        run: pnpm nx affected --target=deploy --configuration=production
-        env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      # Deployment is handled by deploy-soccer-stats.yml. Keep CI limited to
+      # validation so unrelated Vercel deploy targets do not pollute GitHub's
+      # production deployment history for the Soccer Stats app.
       - run: pnpm nx affected --target=docker-build
       - run: pnpm nx affected --target=release

--- a/apps/soccer-stats/api-infra/src/app-runner.ts
+++ b/apps/soccer-stats/api-infra/src/app-runner.ts
@@ -57,6 +57,7 @@ export const service = new aws.apprunner.Service(
           runtimeEnvironmentVariables: {
             NODE_ENV: 'production',
             PORT: containerPort.toString(),
+            CONTAINER_MEMORY_LIMIT_MB: '512',
             DB_SYNCHRONIZE: 'false',
             DB_POOL_MAX: dbPoolMax.toString(),
             DB_POOL_MIN: dbPoolMin.toString(),

--- a/apps/soccer-stats/api/src/app/app.service.spec.ts
+++ b/apps/soccer-stats/api/src/app/app.service.spec.ts
@@ -1,5 +1,7 @@
 import { Test } from '@nestjs/testing';
 
+import { MemorySnapshot } from '../modules/observability/observability.service';
+
 import { AppService } from './app.service';
 
 describe('AppService', () => {
@@ -16,6 +18,70 @@ describe('AppService', () => {
   describe('getData', () => {
     it('should return "Hello API"', () => {
       expect(service.getData()).toEqual({ message: 'Hello API' });
+    });
+  });
+
+  describe('getHealth', () => {
+    const originalContainerMemoryLimit = process.env['CONTAINER_MEMORY_LIMIT_MB'];
+
+    afterEach(() => {
+      if (originalContainerMemoryLimit === undefined) {
+        delete process.env['CONTAINER_MEMORY_LIMIT_MB'];
+      } else {
+        process.env['CONTAINER_MEMORY_LIMIT_MB'] = originalContainerMemoryLimit;
+      }
+    });
+
+    function createServiceWithMemory(snapshot: MemorySnapshot): AppService {
+      return new AppService({
+        getMemorySnapshot: () => snapshot,
+      } as never);
+    }
+
+    it('keeps status ok when V8 heap is mostly full but RSS is low', () => {
+      process.env['CONTAINER_MEMORY_LIMIT_MB'] = '512';
+
+      const result = createServiceWithMemory({
+        heapUsedMB: 46,
+        heapTotalMB: 50,
+        rssMB: 124,
+        externalMB: 5,
+      }).getHealth();
+
+      expect(result.status).toBe('ok');
+      expect(result.memory).toMatchObject({
+        heapUsagePercent: 92,
+        containerLimitMB: 512,
+        rssUsagePercent: 24.22,
+      });
+    });
+
+    it('marks status degraded when RSS exceeds 75 percent of container memory', () => {
+      process.env['CONTAINER_MEMORY_LIMIT_MB'] = '512';
+
+      const result = createServiceWithMemory({
+        heapUsedMB: 80,
+        heapTotalMB: 120,
+        rssMB: 400,
+        externalMB: 10,
+      }).getHealth();
+
+      expect(result.status).toBe('degraded');
+      expect(result.memory?.rssUsagePercent).toBe(78.13);
+    });
+
+    it('marks status unhealthy when RSS exceeds 90 percent of container memory', () => {
+      process.env['CONTAINER_MEMORY_LIMIT_MB'] = '512';
+
+      const result = createServiceWithMemory({
+        heapUsedMB: 100,
+        heapTotalMB: 120,
+        rssMB: 470,
+        externalMB: 10,
+      }).getHealth();
+
+      expect(result.status).toBe('unhealthy');
+      expect(result.memory?.rssUsagePercent).toBe(91.8);
     });
   });
 });

--- a/apps/soccer-stats/api/src/app/app.service.spec.ts
+++ b/apps/soccer-stats/api/src/app/app.service.spec.ts
@@ -1,6 +1,9 @@
 import { Test } from '@nestjs/testing';
 
-import { MemorySnapshot } from '../modules/observability/observability.service';
+import {
+  MemorySnapshot,
+  ObservabilityService,
+} from '../modules/observability/observability.service';
 
 import { AppService } from './app.service';
 
@@ -33,9 +36,14 @@ describe('AppService', () => {
     });
 
     function createServiceWithMemory(snapshot: MemorySnapshot): AppService {
-      return new AppService({
+      const observabilityService: Pick<
+        ObservabilityService,
+        'getMemorySnapshot'
+      > = {
         getMemorySnapshot: () => snapshot,
-      } as never);
+      };
+
+      return new AppService(observabilityService as ObservabilityService);
     }
 
     it('keeps status ok when V8 heap is mostly full but RSS is low', () => {
@@ -68,6 +76,34 @@ describe('AppService', () => {
 
       expect(result.status).toBe('degraded');
       expect(result.memory?.rssUsagePercent).toBe(78.13);
+    });
+
+    it('marks status degraded when RSS is exactly 75 percent of container memory', () => {
+      process.env['CONTAINER_MEMORY_LIMIT_MB'] = '512';
+
+      const result = createServiceWithMemory({
+        heapUsedMB: 80,
+        heapTotalMB: 120,
+        rssMB: 384,
+        externalMB: 10,
+      }).getHealth();
+
+      expect(result.status).toBe('degraded');
+      expect(result.memory?.rssUsagePercent).toBe(75);
+    });
+
+    it('marks status unhealthy when RSS is exactly 90 percent of container memory', () => {
+      process.env['CONTAINER_MEMORY_LIMIT_MB'] = '512';
+
+      const result = createServiceWithMemory({
+        heapUsedMB: 100,
+        heapTotalMB: 120,
+        rssMB: 460.8,
+        externalMB: 10,
+      }).getHealth();
+
+      expect(result.status).toBe('unhealthy');
+      expect(result.memory?.rssUsagePercent).toBe(90);
     });
 
     it('marks status unhealthy when RSS exceeds 90 percent of container memory', () => {

--- a/apps/soccer-stats/api/src/app/app.service.ts
+++ b/apps/soccer-stats/api/src/app/app.service.ts
@@ -13,6 +13,8 @@ export interface MemoryMetrics {
   heapTotalMB: number;
   rssMB: number;
   heapUsagePercent: number;
+  containerLimitMB: number;
+  rssUsagePercent: number;
 }
 
 /**
@@ -50,6 +52,7 @@ export interface ProcessMetrics {
 export class AppService {
   private readonly startTime = Date.now();
   private readonly logger = new Logger(AppService.name);
+  private readonly containerMemoryLimitMB = this.getContainerMemoryLimitMB();
 
   constructor(
     @Optional()
@@ -63,10 +66,14 @@ export class AppService {
   /**
    * Get health status with optional memory metrics.
    *
-   * Status is determined by heap usage:
-   * - ok: < 80% heap usage
-   * - degraded: 80-95% heap usage (high memory pressure)
-   * - unhealthy: > 95% heap usage (critical, may OOM soon)
+   * Status is determined by resident memory usage against the configured
+   * container memory limit. `heapUsed / heapTotal` is still reported for
+   * debugging, but it is intentionally not the health gate: V8 can keep a
+   * small heap nearly full on an otherwise healthy process.
+   *
+   * - ok: RSS < 75% of container limit
+   * - degraded: RSS is 75-90% of container limit
+   * - unhealthy: RSS > 90% of container limit
    */
   getHealth(): HealthStatus {
     const uptime = Math.floor((Date.now() - this.startTime) / 1000);
@@ -82,14 +89,20 @@ export class AppService {
     }
 
     const snapshot = this.observabilityService.getMemorySnapshot();
-    const heapUsagePercent =
-      Math.round((snapshot.heapUsedMB / snapshot.heapTotalMB) * 10000) / 100;
+    const heapUsagePercent = this.toPercent(
+      snapshot.heapUsedMB,
+      snapshot.heapTotalMB,
+    );
+    const rssUsagePercent = this.toPercent(
+      snapshot.rssMB,
+      this.containerMemoryLimitMB,
+    );
 
-    // Determine status based on heap usage
+    // Determine status based on RSS/container memory, not V8 heap fullness.
     let status: 'ok' | 'degraded' | 'unhealthy' = 'ok';
-    if (heapUsagePercent > 95) {
+    if (rssUsagePercent > 90) {
       status = 'unhealthy';
-    } else if (heapUsagePercent > 80) {
+    } else if (rssUsagePercent > 75) {
       status = 'degraded';
     }
 
@@ -102,8 +115,33 @@ export class AppService {
         heapTotalMB: snapshot.heapTotalMB,
         rssMB: snapshot.rssMB,
         heapUsagePercent,
+        containerLimitMB: this.containerMemoryLimitMB,
+        rssUsagePercent,
       },
     };
+  }
+
+  private getContainerMemoryLimitMB(): number {
+    const rawLimit = process.env['CONTAINER_MEMORY_LIMIT_MB'];
+    const parsedLimit = rawLimit ? Number(rawLimit) : 512;
+
+    if (!Number.isFinite(parsedLimit) || parsedLimit <= 0) {
+      this.logger.warn({
+        message: 'Invalid CONTAINER_MEMORY_LIMIT_MB, defaulting to 512MB',
+        value: rawLimit,
+      });
+      return 512;
+    }
+
+    return parsedLimit;
+  }
+
+  private toPercent(used: number, total: number): number {
+    if (total <= 0) {
+      return 0;
+    }
+
+    return Math.round((used / total) * 10000) / 100;
   }
 
   /**

--- a/apps/soccer-stats/api/src/app/app.service.ts
+++ b/apps/soccer-stats/api/src/app/app.service.ts
@@ -100,9 +100,9 @@ export class AppService {
 
     // Determine status based on RSS/container memory, not V8 heap fullness.
     let status: 'ok' | 'degraded' | 'unhealthy' = 'ok';
-    if (rssUsagePercent > 90) {
+    if (rssUsagePercent >= 90) {
       status = 'unhealthy';
-    } else if (rssUsagePercent > 75) {
+    } else if (rssUsagePercent >= 75) {
       status = 'degraded';
     }
 


### PR DESCRIPTION
## Summary
- Remove the stale generic Vercel deploy steps from CI so Chore Board deployments no longer appear as Soccer Stats production deploys.
- Record successful Soccer Stats CD runs as GitHub deployments targeting the CloudFront app URL.
- Change `/api/health` to gate health on RSS/container memory instead of V8 heap fullness, while still reporting heap metrics for debugging.
- Set `CONTAINER_MEMORY_LIMIT_MB=512` in App Runner and add focused health-status tests.

## Test Plan
- [x] `python3` YAML parse for `.github/workflows/main.yml` and `.github/workflows/deploy-soccer-stats.yml`
- [x] `pnpm nx test soccer-stats-api --testFile=app.service.spec.ts`
- [x] `pnpm nx lint soccer-stats-api`
- [x] `pnpm nx build soccer-stats-api`
- [x] `pnpm nx lint soccer-stats-api-infra`
- [x] `pnpm nx build soccer-stats-api-infra`

## Notes
Existing lint warnings remain in unrelated files; no lint errors were introduced.
