### PR TITLE
fix(soccer-stats): show dashboard game team data

### DIFF
--- a/apps/soccer-stats/ui/src/app/components/smart/games-list.smart.tsx
+++ b/apps/soccer-stats/ui/src/app/components/smart/games-list.smart.tsx
@@ -3,6 +3,8 @@ import { useNavigate } from 'react-router';
 
 import { GamesList } from '@garage/soccer-stats/ui-components';
 
+import { findGameTeam, getTeamDisplayName } from '../../utils/game-team-display';
+
 /**
  * Layer 2: Smart Component (Fragment Wrapper) - Temporary without generated GraphQL
  * - Uses existing GraphQL service temporarily during migration
@@ -28,18 +30,14 @@ export const GamesListSmart = ({
   // Transform data to presentation props - temporary implementation
   const games = gameData.map((game: any) => {
     // Business logic: Extract team information
-    const homeTeam = game.teams?.find((gt: any) => gt.teamType === 'HOME')
-      ?.team || { id: '', name: 'TBD' };
-    const awayTeam = game.teams?.find((gt: any) => gt.teamType === 'AWAY')
-      ?.team || { id: '', name: 'TBD' };
+    const homeGameTeam = findGameTeam(game.teams, 'home');
+    const awayGameTeam = findGameTeam(game.teams, 'away');
+    const homeTeam = homeGameTeam?.team || { id: '', name: 'Unassigned' };
+    const awayTeam = awayGameTeam?.team || { id: '', name: 'Unassigned' };
 
     // Business logic: Extract scores
-    const homeScore = game.teams?.find(
-      (gt: any) => gt.teamType === 'HOME',
-    )?.finalScore;
-    const awayScore = game.teams?.find(
-      (gt: any) => gt.teamType === 'AWAY',
-    )?.finalScore;
+    const homeScore = homeGameTeam?.finalScore ?? undefined;
+    const awayScore = awayGameTeam?.finalScore ?? undefined;
 
     return {
       id: game.id,
@@ -52,12 +50,12 @@ export const GamesListSmart = ({
         | 'COMPLETED'
         | 'CANCELLED',
       homeTeam: {
-        id: homeTeam.id,
-        name: homeTeam.name,
+        id: homeTeam.id ?? '',
+        name: getTeamDisplayName(homeGameTeam),
       },
       awayTeam: {
-        id: awayTeam.id,
-        name: awayTeam.name,
+        id: awayTeam.id ?? '',
+        name: getTeamDisplayName(awayGameTeam),
       },
       homeScore,
       awayScore,

--- a/apps/soccer-stats/ui/src/app/pages/dashboard.page.tsx
+++ b/apps/soccer-stats/ui/src/app/pages/dashboard.page.tsx
@@ -2,6 +2,12 @@ import { Link } from 'react-router';
 
 import { useMyDashboard } from '../hooks/use-my-dashboard';
 import { useUserProfile } from '../hooks/use-user-profile';
+import {
+  findGameTeam,
+  formatGameDate,
+  formatGameDateTime,
+  getTeamDisplayName,
+} from '../utils/game-team-display';
 
 /**
  * Dashboard page - main landing page with game overview
@@ -82,8 +88,8 @@ export const DashboardPage = () => {
           </div>
           <div className="space-y-1.5">
             {liveGames.map((game) => {
-              const homeTeam = game.teams?.find((gt) => gt.teamType === 'HOME');
-              const awayTeam = game.teams?.find((gt) => gt.teamType === 'AWAY');
+              const homeTeam = findGameTeam(game.teams, 'home');
+              const awayTeam = findGameTeam(game.teams, 'away');
               return (
                 <Link
                   key={game.id}
@@ -91,13 +97,13 @@ export const DashboardPage = () => {
                   className="flex items-center justify-between rounded bg-white px-3 py-2 shadow-sm transition-shadow hover:shadow"
                 >
                   <span className="text-sm font-medium">
-                    {homeTeam?.team?.shortName || homeTeam?.team?.name}
+                    {getTeamDisplayName(homeTeam)}
                   </span>
                   <span className="rounded bg-gray-100 px-2 py-0.5 text-sm font-bold tabular-nums">
                     {homeTeam?.finalScore ?? 0} – {awayTeam?.finalScore ?? 0}
                   </span>
                   <span className="text-sm font-medium">
-                    {awayTeam?.team?.shortName || awayTeam?.team?.name}
+                    {getTeamDisplayName(awayTeam)}
                   </span>
                   <span className="text-xs text-red-600">View →</span>
                 </Link>
@@ -173,12 +179,8 @@ export const DashboardPage = () => {
             {hasUpcomingGames ? (
               <div className="space-y-0.5">
                 {upcomingGames.map((game) => {
-                  const homeTeam = game.teams?.find(
-                    (gt) => gt.teamType === 'HOME',
-                  );
-                  const awayTeam = game.teams?.find(
-                    (gt) => gt.teamType === 'AWAY',
-                  );
+                  const homeTeam = findGameTeam(game.teams, 'home');
+                  const awayTeam = findGameTeam(game.teams, 'away');
                   return (
                     <Link
                       key={game.id}
@@ -186,22 +188,11 @@ export const DashboardPage = () => {
                       className="block rounded px-2 py-1.5 transition-colors hover:bg-gray-50"
                     >
                       <div className="text-sm font-medium text-gray-900">
-                        {homeTeam?.team?.shortName || 'TBD'} vs{' '}
-                        {awayTeam?.team?.shortName || 'TBD'}
+                        {getTeamDisplayName(homeTeam)} vs{' '}
+                        {getTeamDisplayName(awayTeam)}
                       </div>
                       <div className="text-xs text-gray-500">
-                        {game.scheduledStart
-                          ? new Date(game.scheduledStart).toLocaleDateString(
-                              undefined,
-                              {
-                                weekday: 'short',
-                                month: 'short',
-                                day: 'numeric',
-                                hour: 'numeric',
-                                minute: '2-digit',
-                              },
-                            )
-                          : 'Time TBD'}
+                        {formatGameDateTime(game.scheduledStart)}
                         {game.venue && ` • ${game.venue}`}
                       </div>
                     </Link>
@@ -233,12 +224,8 @@ export const DashboardPage = () => {
             {hasRecentGames ? (
               <div className="space-y-0.5">
                 {recentGames.map((game) => {
-                  const homeTeam = game.teams?.find(
-                    (gt) => gt.teamType === 'HOME',
-                  );
-                  const awayTeam = game.teams?.find(
-                    (gt) => gt.teamType === 'AWAY',
-                  );
+                  const homeTeam = findGameTeam(game.teams, 'home');
+                  const awayTeam = findGameTeam(game.teams, 'away');
                   return (
                     <Link
                       key={game.id}
@@ -246,25 +233,17 @@ export const DashboardPage = () => {
                       className="flex items-center gap-2 rounded px-2 py-1.5 transition-colors hover:bg-gray-50"
                     >
                       <span className="truncate text-sm text-gray-700">
-                        {homeTeam?.team?.shortName || 'Team'}
+                        {getTeamDisplayName(homeTeam)}
                       </span>
                       <span className="mx-auto shrink-0 rounded bg-gray-100 px-2 py-0.5 text-xs font-bold tabular-nums">
                         {homeTeam?.finalScore ?? '–'} –{' '}
                         {awayTeam?.finalScore ?? '–'}
                       </span>
                       <span className="truncate text-right text-sm text-gray-700">
-                        {awayTeam?.team?.shortName || 'Team'}
+                        {getTeamDisplayName(awayTeam)}
                       </span>
                       <span className="shrink-0 text-xs text-gray-400">
-                        {game.actualEnd
-                          ? new Date(game.actualEnd).toLocaleDateString(
-                              undefined,
-                              {
-                                month: 'short',
-                                day: 'numeric',
-                              },
-                            )
-                          : ''}
+                        {formatGameDate(game.actualEnd)}
                       </span>
                     </Link>
                   );

--- a/apps/soccer-stats/ui/src/app/utils/game-team-display.spec.ts
+++ b/apps/soccer-stats/ui/src/app/utils/game-team-display.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  findGameTeam,
+  formatGameDate,
+  formatGameDateTime,
+  getTeamDisplayName,
+} from './game-team-display';
+
+describe('game team display helpers', () => {
+  const teams = [
+    {
+      teamType: 'home',
+      finalScore: 2,
+      team: { name: 'Fierce Jaguars', shortName: 'Jaguars' },
+    },
+    {
+      teamType: 'away',
+      finalScore: 1,
+      team: { name: 'Seattle United NW B15 Black', shortName: null },
+    },
+  ];
+
+  it('finds home and away teams from the lowercase API teamType values', () => {
+    expect(getTeamDisplayName(findGameTeam(teams, 'home'))).toBe('Jaguars');
+    expect(getTeamDisplayName(findGameTeam(teams, 'away'))).toBe(
+      'Seattle United NW B15 Black',
+    );
+  });
+
+  it('also tolerates legacy uppercase teamType values', () => {
+    const legacyTeams = teams.map((team) => ({
+      ...team,
+      teamType: team.teamType.toUpperCase(),
+    }));
+
+    expect(getTeamDisplayName(findGameTeam(legacyTeams, 'home'))).toBe('Jaguars');
+    expect(getTeamDisplayName(findGameTeam(legacyTeams, 'away'))).toBe(
+      'Seattle United NW B15 Black',
+    );
+  });
+
+  it('uses explicit fallback copy instead of leaking TBD/Team placeholders', () => {
+    expect(getTeamDisplayName(undefined)).toBe('Unassigned');
+    expect(formatGameDateTime(null)).toBe('Not scheduled');
+    expect(formatGameDate('not-a-date')).toBe('');
+  });
+});

--- a/apps/soccer-stats/ui/src/app/utils/game-team-display.ts
+++ b/apps/soccer-stats/ui/src/app/utils/game-team-display.ts
@@ -1,0 +1,68 @@
+type TeamLike = {
+  id?: string | null;
+  name?: string | null;
+  shortName?: string | null;
+};
+
+type GameTeamLike = {
+  teamType?: string | null;
+  finalScore?: number | null;
+  team?: TeamLike | null;
+};
+
+const normalizeTeamType = (teamType?: string | null) =>
+  teamType?.trim().toLowerCase();
+
+export const findGameTeam = <T extends GameTeamLike>(
+  teams: readonly T[] | null | undefined,
+  teamType: 'home' | 'away',
+): T | undefined =>
+  teams?.find((gameTeam) => normalizeTeamType(gameTeam.teamType) === teamType);
+
+export const getTeamDisplayName = (
+  gameTeam: GameTeamLike | null | undefined,
+  fallback = 'Unassigned',
+) => gameTeam?.team?.shortName || gameTeam?.team?.name || fallback;
+
+export const formatGameDateTime = (
+  value: string | Date | null | undefined,
+  fallback = 'Not scheduled',
+) => {
+  if (!value) {
+    return fallback;
+  }
+
+  const date = typeof value === 'string' ? new Date(value) : value;
+
+  if (Number.isNaN(date.getTime())) {
+    return fallback;
+  }
+
+  return date.toLocaleDateString(undefined, {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+};
+
+export const formatGameDate = (
+  value: string | Date | null | undefined,
+  fallback = '',
+) => {
+  if (!value) {
+    return fallback;
+  }
+
+  const date = typeof value === 'string' ? new Date(value) : value;
+
+  if (Number.isNaN(date.getTime())) {
+    return fallback;
+  }
+
+  return date.toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+  });
+};


### PR DESCRIPTION
## Summary
- normalize dashboard game team lookups to match lowercase API teamType values
- replace TBD/Team placeholders with real team display names or explicit fallback copy
- share date/team display helpers across dashboard and game list mapping
- add Vitest coverage for lowercase/legacy uppercase teamType handling

## Verification
- pnpm nx test soccer-stats-ui --testFile=game-team-display.spec.ts --skip-nx-cache
- pnpm nx test soccer-stats-ui --skip-nx-cache --runInBand
- pnpm nx lint soccer-stats-ui
- pnpm nx build soccer-stats-ui --skip-nx-cache