### PR TITLE
fix(soccer-stats): format dashboard date-times reliably

### DIFF
--- a/apps/soccer-stats/ui/src/app/utils/game-team-display.spec.ts
+++ b/apps/soccer-stats/ui/src/app/utils/game-team-display.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   findGameTeam,
@@ -8,6 +8,10 @@ import {
 } from './game-team-display';
 
 describe('game team display helpers', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   const teams = [
     {
       teamType: 'home',
@@ -38,6 +42,25 @@ describe('game team display helpers', () => {
     expect(getTeamDisplayName(findGameTeam(legacyTeams, 'away'))).toBe(
       'Seattle United NW B15 Black',
     );
+  });
+
+  it('formats scheduled date-times with the locale string formatter', () => {
+    const toLocaleString = vi
+      .spyOn(Date.prototype, 'toLocaleString')
+      .mockReturnValue('Mon, Jul 13, 5:30 PM');
+    const toLocaleDateString = vi.spyOn(Date.prototype, 'toLocaleDateString');
+
+    expect(formatGameDateTime('2026-07-13T17:30:00.000Z')).toBe(
+      'Mon, Jul 13, 5:30 PM',
+    );
+    expect(toLocaleString).toHaveBeenCalledWith(undefined, {
+      weekday: 'short',
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+    });
+    expect(toLocaleDateString).not.toHaveBeenCalled();
   });
 
   it('uses explicit fallback copy instead of leaking TBD/Team placeholders', () => {

--- a/apps/soccer-stats/ui/src/app/utils/game-team-display.ts
+++ b/apps/soccer-stats/ui/src/app/utils/game-team-display.ts
@@ -38,7 +38,7 @@ export const formatGameDateTime = (
     return fallback;
   }
 
-  return date.toLocaleDateString(undefined, {
+  return date.toLocaleString(undefined, {
     weekday: 'short',
     month: 'short',
     day: 'numeric',


### PR DESCRIPTION
## Summary
- addresses Copilot feedback from PR #272
- uses `toLocaleString()` for dashboard scheduled date-time formatting so hour/minute options are reliably honored
- adds Vitest coverage proving `formatGameDateTime()` uses the locale string formatter rather than date-only formatting

## Verification
- `pnpm nx test soccer-stats-ui --testFile=game-team-display.spec.ts --skip-nx-cache`
- `pnpm nx build soccer-stats-ui --skip-nx-cache`
- `pnpm nx lint soccer-stats-ui`
- `pnpm nx test soccer-stats-ui --skip-nx-cache --runInBand`