### PR TITLE
feat(soccer-stats): import games from PlayMetrics calendars

### DIFF
--- a/apps/soccer-stats/api/src/app/app.module.ts
+++ b/apps/soccer-stats/api/src/app/app.module.ts
@@ -17,6 +17,7 @@ import { EventTypesModule } from '../modules/event-types/event-types.module';
 import { GameEventsModule } from '../modules/game-events/game-events.module';
 import { TeamMembersModule } from '../modules/team-members/team-members.module';
 import { TeamStatsModule } from '../modules/team-stats/team-stats.module';
+import { CalendarSyncModule } from '../modules/calendar-sync/calendar-sync.module';
 import { MyModule } from '../modules/my/my.module';
 import { PubSubModule } from '../modules/pubsub/pubsub.module';
 import { DataLoadersModule, DataLoadersService } from '../modules/dataloaders';
@@ -126,6 +127,7 @@ interface AuthenticatedRequest extends Request {
     GameEventsModule,
     TeamMembersModule,
     TeamStatsModule,
+    CalendarSyncModule,
     MyModule,
   ],
   controllers: [AppController, ConfigController],

--- a/apps/soccer-stats/api/src/database/migrations/1776100000000-AddTeamCalendarSources.ts
+++ b/apps/soccer-stats/api/src/database/migrations/1776100000000-AddTeamCalendarSources.ts
@@ -1,0 +1,58 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddTeamCalendarSources1776100000000 implements MigrationInterface {
+  name = 'AddTeamCalendarSources1776100000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "team_calendar_sources" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        "teamId" uuid NOT NULL,
+        "provider" character varying(50) NOT NULL,
+        "feedUrl" text NOT NULL,
+        "calendarName" character varying(255),
+        "enabled" boolean NOT NULL DEFAULT true,
+        "lastSyncedAt" TIMESTAMP WITH TIME ZONE,
+        "lastSyncStatus" character varying(30) NOT NULL DEFAULT 'never_synced',
+        "lastSyncError" text,
+        CONSTRAINT "PK_team_calendar_sources" PRIMARY KEY ("id"),
+        CONSTRAINT "FK_team_calendar_sources_team" FOREIGN KEY ("teamId") REFERENCES "teams"("id") ON DELETE CASCADE
+      )
+    `);
+
+    await queryRunner.query(
+      `CREATE INDEX "IDX_team_calendar_sources_teamId" ON "team_calendar_sources" ("teamId")`,
+    );
+
+    await queryRunner.query(`
+      CREATE TABLE "external_game_mappings" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        "calendarSourceId" uuid NOT NULL,
+        "gameId" uuid NOT NULL,
+        "externalUid" character varying(255) NOT NULL,
+        "externalSequence" integer,
+        "externalCreatedAt" TIMESTAMP WITH TIME ZONE,
+        "externalLastModified" TIMESTAMP WITH TIME ZONE,
+        CONSTRAINT "PK_external_game_mappings" PRIMARY KEY ("id"),
+        CONSTRAINT "UQ_external_game_mappings_source_uid" UNIQUE ("calendarSourceId", "externalUid"),
+        CONSTRAINT "FK_external_game_mappings_source" FOREIGN KEY ("calendarSourceId") REFERENCES "team_calendar_sources"("id") ON DELETE CASCADE,
+        CONSTRAINT "FK_external_game_mappings_game" FOREIGN KEY ("gameId") REFERENCES "games"("id") ON DELETE CASCADE
+      )
+    `);
+
+    await queryRunner.query(
+      `CREATE INDEX "IDX_external_game_mappings_gameId" ON "external_game_mappings" ("gameId")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "IDX_external_game_mappings_gameId"`);
+    await queryRunner.query(`DROP TABLE "external_game_mappings"`);
+    await queryRunner.query(`DROP INDEX "IDX_team_calendar_sources_teamId"`);
+    await queryRunner.query(`DROP TABLE "team_calendar_sources"`);
+  }
+}

--- a/apps/soccer-stats/api/src/database/migrations/index.ts
+++ b/apps/soccer-stats/api/src/database/migrations/index.ts
@@ -34,6 +34,7 @@ import { CreatePlayerPositionPlaytimeView1770300000000 } from './1770300000000-C
 import { DefaultFinalScoreToZero1775509578482 } from './1775509578482-DefaultFinalScoreToZero';
 import { CreateGameEventsDetailView1775600000000 } from './1775600000000-CreateGameEventsDetailView';
 import { RemoveFinalScoreColumn1776000000000 } from './1776000000000-RemoveFinalScoreColumn';
+import { AddTeamCalendarSources1776100000000 } from './1776100000000-AddTeamCalendarSources';
 
 /**
  * All migrations in chronological order.
@@ -65,4 +66,5 @@ export const migrations = [
   DefaultFinalScoreToZero1775509578482,
   CreateGameEventsDetailView1775600000000,
   RemoveFinalScoreColumn1776000000000,
+  AddTeamCalendarSources1776100000000,
 ];

--- a/apps/soccer-stats/api/src/entities/calendar-source.entity.ts
+++ b/apps/soccer-stats/api/src/entities/calendar-source.entity.ts
@@ -1,0 +1,75 @@
+import { Entity, Column, ManyToOne, JoinColumn, OneToMany } from 'typeorm';
+import { ObjectType, Field, ID, registerEnumType } from '@nestjs/graphql';
+
+import { BaseEntity } from './base.entity';
+import { Team } from './team.entity';
+import { ExternalGameMapping } from './external-game-mapping.entity';
+
+export enum CalendarProvider {
+  PLAYMETRICS = 'playmetrics',
+}
+
+export enum CalendarSyncStatus {
+  NEVER_SYNCED = 'never_synced',
+  SUCCESS = 'success',
+  ERROR = 'error',
+}
+
+registerEnumType(CalendarProvider, {
+  name: 'CalendarProvider',
+  description: 'External calendar provider used as a team schedule source',
+});
+
+registerEnumType(CalendarSyncStatus, {
+  name: 'CalendarSyncStatus',
+  description: 'Most recent sync result for a team calendar source',
+});
+
+@ObjectType()
+@Entity('team_calendar_sources')
+export class CalendarSource extends BaseEntity {
+  @Field(() => ID)
+  @Column('uuid')
+  teamId!: string;
+
+  @Field(() => CalendarProvider)
+  @Column({ type: 'varchar', length: 50 })
+  provider!: CalendarProvider;
+
+  @Field()
+  @Column({ type: 'text' })
+  feedUrl!: string;
+
+  @Field({ nullable: true })
+  @Column({ length: 255, nullable: true })
+  calendarName?: string;
+
+  @Field()
+  @Column({ default: true })
+  enabled!: boolean;
+
+  @Field({ nullable: true })
+  @Column({ type: 'timestamptz', nullable: true })
+  lastSyncedAt?: Date;
+
+  @Field(() => CalendarSyncStatus)
+  @Column({
+    type: 'varchar',
+    length: 30,
+    default: CalendarSyncStatus.NEVER_SYNCED,
+  })
+  lastSyncStatus!: CalendarSyncStatus;
+
+  @Field({ nullable: true })
+  @Column({ type: 'text', nullable: true })
+  lastSyncError?: string;
+
+  @Field(() => Team)
+  @ManyToOne(() => Team, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'teamId' })
+  team!: Team;
+
+  @Field(() => [ExternalGameMapping], { nullable: true })
+  @OneToMany(() => ExternalGameMapping, (mapping) => mapping.calendarSource)
+  externalGameMappings?: ExternalGameMapping[];
+}

--- a/apps/soccer-stats/api/src/entities/external-game-mapping.entity.ts
+++ b/apps/soccer-stats/api/src/entities/external-game-mapping.entity.ts
@@ -1,0 +1,50 @@
+import { Entity, Column, ManyToOne, JoinColumn, Unique } from 'typeorm';
+import { ObjectType, Field, ID } from '@nestjs/graphql';
+
+import { BaseEntity } from './base.entity';
+import { CalendarSource } from './calendar-source.entity';
+import { Game } from './game.entity';
+
+@ObjectType()
+@Entity('external_game_mappings')
+@Unique('UQ_external_game_mappings_source_uid', [
+  'calendarSourceId',
+  'externalUid',
+])
+export class ExternalGameMapping extends BaseEntity {
+  @Field(() => ID)
+  @Column('uuid')
+  calendarSourceId!: string;
+
+  @Field(() => ID)
+  @Column('uuid')
+  gameId!: string;
+
+  @Field()
+  @Column({ length: 255 })
+  externalUid!: string;
+
+  @Field({ nullable: true })
+  @Column({ type: 'int', nullable: true })
+  externalSequence?: number;
+
+  @Field({ nullable: true })
+  @Column({ type: 'timestamptz', nullable: true })
+  externalCreatedAt?: Date;
+
+  @Field({ nullable: true })
+  @Column({ type: 'timestamptz', nullable: true })
+  externalLastModified?: Date;
+
+  @Field(() => CalendarSource)
+  @ManyToOne(() => CalendarSource, (source) => source.externalGameMappings, {
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'calendarSourceId' })
+  calendarSource!: CalendarSource;
+
+  @Field(() => Game)
+  @ManyToOne(() => Game, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'gameId' })
+  game!: Game;
+}

--- a/apps/soccer-stats/api/src/modules/calendar-sync/calendar-sync-scheduler.service.ts
+++ b/apps/soccer-stats/api/src/modules/calendar-sync/calendar-sync-scheduler.service.ts
@@ -15,6 +15,7 @@ export class CalendarSyncSchedulerService
 {
   private readonly logger = new Logger(CalendarSyncSchedulerService.name);
   private timer?: NodeJS.Timeout;
+  private syncInProgress = false;
 
   constructor(private readonly calendarSyncService: CalendarSyncService) {}
 
@@ -42,6 +43,15 @@ export class CalendarSyncSchedulerService
   }
 
   private async syncEnabledSources(): Promise<void> {
+    if (this.syncInProgress) {
+      this.logger.warn(
+        'Skipping team calendar sync: previous sync still running',
+      );
+      return;
+    }
+
+    this.syncInProgress = true;
+
     try {
       const results = await this.calendarSyncService.syncEnabledSources();
       const created = results.reduce((sum, result) => sum + result.created, 0);
@@ -57,6 +67,8 @@ export class CalendarSyncSchedulerService
       this.logger.error(
         `Team calendar sync failed: ${error instanceof Error ? error.message : String(error)}`,
       );
+    } finally {
+      this.syncInProgress = false;
     }
   }
 

--- a/apps/soccer-stats/api/src/modules/calendar-sync/calendar-sync-scheduler.service.ts
+++ b/apps/soccer-stats/api/src/modules/calendar-sync/calendar-sync-scheduler.service.ts
@@ -1,0 +1,72 @@
+import {
+  Injectable,
+  Logger,
+  OnApplicationBootstrap,
+  OnApplicationShutdown,
+} from '@nestjs/common';
+
+import { CalendarSyncService } from './calendar-sync.service';
+
+const DEFAULT_SYNC_INTERVAL_MS = 60 * 60 * 1000;
+
+@Injectable()
+export class CalendarSyncSchedulerService
+  implements OnApplicationBootstrap, OnApplicationShutdown
+{
+  private readonly logger = new Logger(CalendarSyncSchedulerService.name);
+  private timer?: NodeJS.Timeout;
+
+  constructor(private readonly calendarSyncService: CalendarSyncService) {}
+
+  onApplicationBootstrap(): void {
+    const intervalMs = this.getIntervalMs();
+    if (intervalMs <= 0) {
+      this.logger.log('Team calendar sync scheduler disabled');
+      return;
+    }
+
+    this.timer = setInterval(() => {
+      void this.syncEnabledSources();
+    }, intervalMs);
+    this.timer.unref?.();
+    this.logger.log(
+      `Team calendar sync scheduler enabled every ${intervalMs}ms`,
+    );
+  }
+
+  onApplicationShutdown(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = undefined;
+    }
+  }
+
+  private async syncEnabledSources(): Promise<void> {
+    try {
+      const results = await this.calendarSyncService.syncEnabledSources();
+      const created = results.reduce((sum, result) => sum + result.created, 0);
+      const updated = results.reduce((sum, result) => sum + result.updated, 0);
+      const errors = results.reduce(
+        (sum, result) => sum + result.errors.length,
+        0,
+      );
+      this.logger.log(
+        `Team calendar sync complete: sources=${results.length} created=${created} updated=${updated} errors=${errors}`,
+      );
+    } catch (error) {
+      this.logger.error(
+        `Team calendar sync failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  private getIntervalMs(): number {
+    const raw = process.env['TEAM_CALENDAR_SYNC_INTERVAL_MS'];
+    if (!raw) {
+      return DEFAULT_SYNC_INTERVAL_MS;
+    }
+
+    const parsed = Number(raw);
+    return Number.isFinite(parsed) ? parsed : DEFAULT_SYNC_INTERVAL_MS;
+  }
+}

--- a/apps/soccer-stats/api/src/modules/calendar-sync/calendar-sync.module.ts
+++ b/apps/soccer-stats/api/src/modules/calendar-sync/calendar-sync.module.ts
@@ -1,0 +1,39 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { CalendarSource } from '../../entities/calendar-source.entity';
+import { ExternalGameMapping } from '../../entities/external-game-mapping.entity';
+import { Game } from '../../entities/game.entity';
+import { GameTeam } from '../../entities/game-team.entity';
+import { GameFormat } from '../../entities/game-format.entity';
+import { Team } from '../../entities/team.entity';
+import { TeamConfiguration } from '../../entities/team-configuration.entity';
+import { AuthModule } from '../auth/auth.module';
+
+import { CalendarSyncResolver } from './calendar-sync.resolver';
+import { CalendarSyncSchedulerService } from './calendar-sync-scheduler.service';
+import { CalendarSyncService } from './calendar-sync.service';
+import { PlayMetricsIcsParserService } from './playmetrics-ics-parser.service';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([
+      CalendarSource,
+      ExternalGameMapping,
+      Game,
+      GameTeam,
+      GameFormat,
+      Team,
+      TeamConfiguration,
+    ]),
+    AuthModule,
+  ],
+  providers: [
+    CalendarSyncResolver,
+    CalendarSyncSchedulerService,
+    CalendarSyncService,
+    PlayMetricsIcsParserService,
+  ],
+  exports: [CalendarSyncService],
+})
+export class CalendarSyncModule {}

--- a/apps/soccer-stats/api/src/modules/calendar-sync/calendar-sync.resolver.ts
+++ b/apps/soccer-stats/api/src/modules/calendar-sync/calendar-sync.resolver.ts
@@ -1,0 +1,62 @@
+import { Args, ID, Mutation, Query, Resolver } from '@nestjs/graphql';
+import { UseGuards } from '@nestjs/common';
+
+import { CalendarSource } from '../../entities/calendar-source.entity';
+import { ClerkAuthGuard } from '../auth/clerk-auth.guard';
+import { TeamAccessGuard } from '../auth/team-access.guard';
+import { RequireTeamRole } from '../auth/require-team-role.decorator';
+import { TeamRole } from '../../entities/team-member.entity';
+
+import { CalendarSyncService } from './calendar-sync.service';
+import { CreateCalendarSourceInput } from './dto/create-calendar-source.input';
+import { CalendarSyncResultType } from './dto/calendar-sync-result.type';
+
+@Resolver(() => CalendarSource)
+export class CalendarSyncResolver {
+  constructor(private readonly calendarSyncService: CalendarSyncService) {}
+
+  @Query(() => [CalendarSource], {
+    name: 'teamCalendarSources',
+    description: 'Calendar feeds connected to a team for schedule imports',
+  })
+  @UseGuards(ClerkAuthGuard, TeamAccessGuard)
+  @RequireTeamRole([TeamRole.OWNER, TeamRole.MANAGER, TeamRole.COACH], {
+    teamIdArg: 'teamId',
+  })
+  teamCalendarSources(
+    @Args('teamId', { type: () => ID }) teamId: string,
+  ): Promise<CalendarSource[]> {
+    return this.calendarSyncService.findSourcesForTeam(teamId);
+  }
+
+  @Mutation(() => CalendarSource, {
+    name: 'createTeamCalendarSource',
+    description:
+      'Connect a team to an external calendar feed, such as PlayMetrics ICS',
+  })
+  @UseGuards(ClerkAuthGuard, TeamAccessGuard)
+  @RequireTeamRole([TeamRole.OWNER, TeamRole.MANAGER], {
+    teamIdPath: 'input.teamId',
+  })
+  createTeamCalendarSource(
+    @Args('input') input: CreateCalendarSourceInput,
+  ): Promise<CalendarSource> {
+    return this.calendarSyncService.createSource(input);
+  }
+
+  @Mutation(() => CalendarSyncResultType, {
+    name: 'syncTeamCalendarSource',
+    description:
+      'Immediately import or update games from a connected team calendar feed',
+  })
+  @UseGuards(ClerkAuthGuard, TeamAccessGuard)
+  @RequireTeamRole([TeamRole.OWNER, TeamRole.MANAGER, TeamRole.COACH], {
+    teamIdArg: 'teamId',
+  })
+  syncTeamCalendarSource(
+    @Args('teamId', { type: () => ID }) teamId: string,
+    @Args('sourceId', { type: () => ID }) sourceId: string,
+  ): Promise<CalendarSyncResultType> {
+    return this.calendarSyncService.syncSource(sourceId, teamId);
+  }
+}

--- a/apps/soccer-stats/api/src/modules/calendar-sync/calendar-sync.service.spec.ts
+++ b/apps/soccer-stats/api/src/modules/calendar-sync/calendar-sync.service.spec.ts
@@ -196,4 +196,14 @@ describe('CalendarSyncService', () => {
     expect(results).toHaveLength(2);
     expect(service.fetchFeed).toHaveBeenCalledTimes(2);
   });
+
+  it('rejects non-PlayMetrics calendar URLs before saving a source', async () => {
+    await expect(
+      service.createSource({
+        teamId: managedTeam.id,
+        provider: CalendarProvider.PLAYMETRICS,
+        feedUrl: 'http://169.254.169.254/latest/meta-data',
+      }),
+    ).rejects.toThrow('PlayMetrics calendar feed URL must use HTTPS');
+  });
 });

--- a/apps/soccer-stats/api/src/modules/calendar-sync/calendar-sync.service.spec.ts
+++ b/apps/soccer-stats/api/src/modules/calendar-sync/calendar-sync.service.spec.ts
@@ -1,0 +1,199 @@
+import {
+  CalendarProvider,
+  CalendarSource,
+} from '../../entities/calendar-source.entity';
+import { ExternalGameMapping } from '../../entities/external-game-mapping.entity';
+import { Game, GameStatus } from '../../entities/game.entity';
+import { GameTeam } from '../../entities/game-team.entity';
+import { GameFormat } from '../../entities/game-format.entity';
+import { Team, SourceType } from '../../entities/team.entity';
+import { TeamConfiguration } from '../../entities/team-configuration.entity';
+
+import { CalendarSyncService } from './calendar-sync.service';
+import { PlayMetricsIcsParserService } from './playmetrics-ics-parser.service';
+
+const sampleIcs = `BEGIN:VCALENDAR
+X-WR-CALNAME:BU12 Select Airey Games
+X-PUBLISHED-TTL:PT1H
+BEGIN:VEVENT
+UID:Game_4494939
+LAST-MODIFIED:20260706T191149Z
+SEQUENCE:1783365109
+DTSTART;TZID=America/Los_Angeles:20260710T150000
+DTEND;TZID=America/Los_Angeles:20260710T160000
+SUMMARY:BU12 Select Airey - Game
+DESCRIPTION:BU12 Select Airey at Northshore Select SC BU12C (Cornucopia Game #1)\\nArrive by 2:30 PM\\nUniform: Black Jersey\\, Black Shorts\\, Black Socks\\nNorth Green River Park #4
+LOCATION:26352 Green River Rd\\, Kent\\, WA 98030
+STATUS:CONFIRMED
+END:VEVENT
+END:VCALENDAR`;
+
+type RepoMock<T> = {
+  findOne: jest.Mock;
+  find: jest.Mock;
+  create: jest.Mock<T, [Partial<T>]>;
+  save: jest.Mock;
+};
+
+function repo<T>(): RepoMock<T> {
+  return {
+    findOne: jest.fn(),
+    find: jest.fn(),
+    create: jest.fn((input: Partial<T>) => input as T),
+    save: jest.fn(async (input: T | T[]) => input as T),
+  };
+}
+
+describe('CalendarSyncService', () => {
+  const managedTeam = {
+    id: 'team-managed',
+    name: 'BU12 Select Airey',
+    isManaged: true,
+    sourceType: SourceType.INTERNAL,
+  } as Team;
+  const defaultGameFormat = {
+    id: 'format-9v9',
+    durationMinutes: 60,
+  } as GameFormat;
+  const source = {
+    id: 'source-1',
+    teamId: managedTeam.id,
+    provider: CalendarProvider.PLAYMETRICS,
+    feedUrl:
+      'https://calendar.playmetrics.com/calendars/c755/t537361/p0/tF6BE3E68/f/games-calendar.ics',
+    enabled: true,
+    team: managedTeam,
+  } as CalendarSource;
+
+  let calendarSourceRepo: RepoMock<CalendarSource>;
+  let mappingRepo: RepoMock<ExternalGameMapping>;
+  let gameRepo: RepoMock<Game>;
+  let gameTeamRepo: RepoMock<GameTeam>;
+  let teamRepo: RepoMock<Team>;
+  let teamConfigRepo: RepoMock<TeamConfiguration>;
+  let gameFormatRepo: RepoMock<GameFormat>;
+  let service: CalendarSyncService;
+
+  beforeEach(() => {
+    calendarSourceRepo = repo<CalendarSource>();
+    mappingRepo = repo<ExternalGameMapping>();
+    gameRepo = repo<Game>();
+    gameTeamRepo = repo<GameTeam>();
+    teamRepo = repo<Team>();
+    teamConfigRepo = repo<TeamConfiguration>();
+    gameFormatRepo = repo<GameFormat>();
+
+    calendarSourceRepo.findOne.mockResolvedValue(source);
+    mappingRepo.findOne.mockResolvedValue(null);
+    teamConfigRepo.findOne.mockResolvedValue({
+      defaultGameFormatId: defaultGameFormat.id,
+      defaultGameDuration: 60,
+      statsFeatures: { trackGoals: true },
+    });
+    gameFormatRepo.findOne.mockResolvedValue(defaultGameFormat);
+    teamRepo.findOne.mockResolvedValueOnce(null);
+    teamRepo.save.mockImplementation(async (team) =>
+      Object.assign(team as Team, { id: 'team-opponent' }),
+    );
+    gameRepo.save.mockImplementation(async (game) =>
+      Object.assign(game as Game, { id: 'game-1' }),
+    );
+
+    service = new CalendarSyncService(
+      calendarSourceRepo as never,
+      mappingRepo as never,
+      gameRepo as never,
+      gameTeamRepo as never,
+      teamRepo as never,
+      teamConfigRepo as never,
+      gameFormatRepo as never,
+      new PlayMetricsIcsParserService(),
+    );
+    jest.spyOn(service, 'fetchFeed').mockResolvedValue(sampleIcs);
+  });
+
+  it('creates a scheduled game, opponent team, game teams, and mapping from a PlayMetrics feed', async () => {
+    const result = await service.syncSource(source.id);
+
+    expect(result).toMatchObject({ created: 1, updated: 0, skipped: 0 });
+    expect(teamRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'Northshore Select SC BU12C',
+        isManaged: false,
+        sourceType: SourceType.EXTERNAL,
+        externalReference: 'playmetrics:Northshore Select SC BU12C',
+      }),
+    );
+    expect(gameRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        gameFormatId: defaultGameFormat.id,
+        name: 'BU12 Select Airey - Game',
+        scheduledStart: new Date('2026-07-10T22:00:00.000Z'),
+        venue: '26352 Green River Rd, Kent, WA 98030',
+        status: GameStatus.SCHEDULED,
+        durationMinutes: 60,
+      }),
+    );
+    expect(gameTeamRepo.save).toHaveBeenCalledWith([
+      expect.objectContaining({
+        gameId: 'game-1',
+        teamId: 'team-opponent',
+        teamType: 'home',
+      }),
+      expect.objectContaining({
+        gameId: 'game-1',
+        teamId: managedTeam.id,
+        teamType: 'away',
+      }),
+    ]);
+    expect(mappingRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        calendarSourceId: source.id,
+        gameId: 'game-1',
+        externalUid: 'Game_4494939',
+        externalSequence: 1783365109,
+      }),
+    );
+  });
+
+  it('updates an existing mapped game when PlayMetrics changes the event', async () => {
+    const existingGame = {
+      id: 'game-existing',
+      status: GameStatus.SCHEDULED,
+    } as Game;
+    mappingRepo.findOne.mockResolvedValue({
+      id: 'mapping-1',
+      gameId: existingGame.id,
+      game: existingGame,
+      externalUid: 'Game_4494939',
+      externalSequence: 1,
+    } as ExternalGameMapping);
+
+    const result = await service.syncSource(source.id);
+
+    expect(result).toMatchObject({ created: 0, updated: 1, skipped: 0 });
+    expect(gameRepo.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: existingGame.id,
+        scheduledStart: new Date('2026-07-10T22:00:00.000Z'),
+        venue: '26352 Green River Rd, Kent, WA 98030',
+      }),
+    );
+  });
+
+  it('syncs all enabled calendar sources for scheduled automation', async () => {
+    const secondSource = { ...source, id: 'source-2' } as CalendarSource;
+    calendarSourceRepo.find.mockResolvedValue([source, secondSource]);
+    calendarSourceRepo.findOne
+      .mockResolvedValueOnce(source)
+      .mockResolvedValueOnce(secondSource);
+
+    const results = await service.syncEnabledSources();
+
+    expect(calendarSourceRepo.find).toHaveBeenCalledWith({
+      where: { enabled: true },
+    });
+    expect(results).toHaveLength(2);
+    expect(service.fetchFeed).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/soccer-stats/api/src/modules/calendar-sync/calendar-sync.service.ts
+++ b/apps/soccer-stats/api/src/modules/calendar-sync/calendar-sync.service.ts
@@ -1,0 +1,383 @@
+import {
+  Injectable,
+  NotFoundException,
+  BadRequestException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import axios from 'axios';
+import { Repository } from 'typeorm';
+
+import {
+  CalendarProvider,
+  CalendarSource,
+  CalendarSyncStatus,
+} from '../../entities/calendar-source.entity';
+import { ExternalGameMapping } from '../../entities/external-game-mapping.entity';
+import { Game, GameStatus } from '../../entities/game.entity';
+import { GameTeam } from '../../entities/game-team.entity';
+import { GameFormat } from '../../entities/game-format.entity';
+import { Team, SourceType } from '../../entities/team.entity';
+import { TeamConfiguration } from '../../entities/team-configuration.entity';
+
+import {
+  ImportedCalendarGame,
+  PlayMetricsIcsParserService,
+} from './playmetrics-ics-parser.service';
+
+export interface CalendarSyncResult {
+  sourceId: string;
+  created: number;
+  updated: number;
+  skipped: number;
+  errors: string[];
+}
+
+@Injectable()
+export class CalendarSyncService {
+  constructor(
+    @InjectRepository(CalendarSource)
+    private readonly calendarSourceRepository: Repository<CalendarSource>,
+    @InjectRepository(ExternalGameMapping)
+    private readonly externalGameMappingRepository: Repository<ExternalGameMapping>,
+    @InjectRepository(Game)
+    private readonly gameRepository: Repository<Game>,
+    @InjectRepository(GameTeam)
+    private readonly gameTeamRepository: Repository<GameTeam>,
+    @InjectRepository(Team)
+    private readonly teamRepository: Repository<Team>,
+    @InjectRepository(TeamConfiguration)
+    private readonly teamConfigurationRepository: Repository<TeamConfiguration>,
+    @InjectRepository(GameFormat)
+    private readonly gameFormatRepository: Repository<GameFormat>,
+    private readonly playMetricsIcsParser: PlayMetricsIcsParserService,
+  ) {}
+
+  async createSource(input: {
+    teamId: string;
+    provider: CalendarProvider;
+    feedUrl: string;
+    enabled?: boolean;
+  }): Promise<CalendarSource> {
+    this.validateFeedUrl(input.feedUrl);
+    const team = await this.teamRepository.findOne({
+      where: { id: input.teamId },
+    });
+    if (!team) {
+      throw new NotFoundException(`Team with ID "${input.teamId}" not found`);
+    }
+
+    const source = this.calendarSourceRepository.create({
+      teamId: input.teamId,
+      provider: input.provider,
+      feedUrl: input.feedUrl,
+      enabled: input.enabled ?? true,
+      lastSyncStatus: CalendarSyncStatus.NEVER_SYNCED,
+    });
+
+    return this.calendarSourceRepository.save(source);
+  }
+
+  async findSourcesForTeam(teamId: string): Promise<CalendarSource[]> {
+    return this.calendarSourceRepository.find({
+      where: { teamId },
+      order: { createdAt: 'ASC' },
+    });
+  }
+
+  async syncEnabledSources(): Promise<CalendarSyncResult[]> {
+    const sources = await this.calendarSourceRepository.find({
+      where: { enabled: true },
+    });
+
+    const results: CalendarSyncResult[] = [];
+    for (const source of sources) {
+      results.push(await this.syncSource(source.id));
+    }
+
+    return results;
+  }
+
+  async syncSource(
+    sourceId: string,
+    expectedTeamId?: string,
+  ): Promise<CalendarSyncResult> {
+    const source = await this.calendarSourceRepository.findOne({
+      where: { id: sourceId },
+      relations: { team: true },
+    });
+
+    if (!source) {
+      throw new NotFoundException(
+        `Calendar source with ID "${sourceId}" not found`,
+      );
+    }
+    if (expectedTeamId && source.teamId !== expectedTeamId) {
+      throw new NotFoundException(
+        `Calendar source with ID "${sourceId}" not found for team "${expectedTeamId}"`,
+      );
+    }
+    if (!source.enabled) {
+      return { sourceId, created: 0, updated: 0, skipped: 0, errors: [] };
+    }
+
+    const result: CalendarSyncResult = {
+      sourceId,
+      created: 0,
+      updated: 0,
+      skipped: 0,
+      errors: [],
+    };
+
+    try {
+      const ics = await this.fetchFeed(source.feedUrl);
+      const parsed = this.parseSourceFeed(source, ics);
+      source.calendarName = parsed.calendarName;
+
+      for (const game of parsed.games) {
+        try {
+          const outcome = await this.upsertGame(source, game);
+          result[outcome] += 1;
+        } catch (error) {
+          result.errors.push(
+            `${game.uid}: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+      }
+
+      source.lastSyncedAt = new Date();
+      source.lastSyncStatus =
+        result.errors.length > 0
+          ? CalendarSyncStatus.ERROR
+          : CalendarSyncStatus.SUCCESS;
+      source.lastSyncError =
+        result.errors.length > 0 ? result.errors.join('\n') : undefined;
+      await this.calendarSourceRepository.save(source);
+
+      return result;
+    } catch (error) {
+      source.lastSyncedAt = new Date();
+      source.lastSyncStatus = CalendarSyncStatus.ERROR;
+      source.lastSyncError =
+        error instanceof Error ? error.message : String(error);
+      await this.calendarSourceRepository.save(source);
+      throw error;
+    }
+  }
+
+  async fetchFeed(feedUrl: string): Promise<string> {
+    this.validateFeedUrl(feedUrl);
+    const response = await axios.get<string>(feedUrl, {
+      responseType: 'text',
+      timeout: 15_000,
+      maxRedirects: 3,
+    });
+
+    return response.data;
+  }
+
+  private parseSourceFeed(source: CalendarSource, ics: string) {
+    switch (source.provider) {
+      case CalendarProvider.PLAYMETRICS:
+        return this.playMetricsIcsParser.parse(ics);
+      default:
+        throw new BadRequestException(
+          `Unsupported calendar provider ${source.provider}`,
+        );
+    }
+  }
+
+  private async upsertGame(
+    source: CalendarSource,
+    imported: ImportedCalendarGame,
+  ): Promise<'created' | 'updated' | 'skipped'> {
+    const mapping = await this.externalGameMappingRepository.findOne({
+      where: {
+        calendarSourceId: source.id,
+        externalUid: imported.uid,
+      },
+      relations: { game: true },
+    });
+
+    if (mapping?.game) {
+      await this.updateMappedGame(mapping, imported);
+      return 'updated';
+    }
+
+    const managedTeam = source.team ?? (await this.getTeam(source.teamId));
+    const opponentTeam = await this.findOrCreateOpponentTeam(source, imported);
+    const gameFormat = await this.resolveGameFormat(source.teamId);
+    const durationMinutes = this.durationMinutes(
+      imported,
+      gameFormat.durationMinutes,
+    );
+    const game = this.gameRepository.create({
+      gameFormatId: gameFormat.id,
+      name: imported.summary,
+      scheduledStart: imported.startsAt,
+      venue: imported.location,
+      notes: this.buildGameNotes(imported),
+      status: this.toGameStatus(imported.status),
+      durationMinutes,
+    });
+    const savedGame = await this.gameRepository.save(game);
+    const isManagedHome = imported.homeTeamName === imported.managedTeamName;
+
+    await this.gameTeamRepository.save([
+      this.gameTeamRepository.create({
+        gameId: savedGame.id,
+        teamId: isManagedHome ? managedTeam.id : opponentTeam.id,
+        teamType: 'home',
+      }),
+      this.gameTeamRepository.create({
+        gameId: savedGame.id,
+        teamId: isManagedHome ? opponentTeam.id : managedTeam.id,
+        teamType: 'away',
+      }),
+    ]);
+
+    await this.externalGameMappingRepository.save(
+      this.externalGameMappingRepository.create({
+        calendarSourceId: source.id,
+        gameId: savedGame.id,
+        externalUid: imported.uid,
+        externalSequence: imported.sequence,
+        externalCreatedAt: imported.created,
+        externalLastModified: imported.lastModified,
+      }),
+    );
+
+    return 'created';
+  }
+
+  private async updateMappedGame(
+    mapping: ExternalGameMapping,
+    imported: ImportedCalendarGame,
+  ): Promise<void> {
+    const game = mapping.game;
+    game.name = imported.summary;
+    game.scheduledStart = imported.startsAt;
+    game.venue = imported.location;
+    game.notes = this.buildGameNotes(imported);
+    game.status = this.toGameStatus(imported.status);
+    game.durationMinutes = this.durationMinutes(imported, game.durationMinutes);
+
+    await this.gameRepository.save(game);
+
+    mapping.externalSequence = imported.sequence;
+    mapping.externalCreatedAt = imported.created;
+    mapping.externalLastModified = imported.lastModified;
+    await this.externalGameMappingRepository.save(mapping);
+  }
+
+  private async findOrCreateOpponentTeam(
+    source: CalendarSource,
+    imported: ImportedCalendarGame,
+  ): Promise<Team> {
+    const opponentName = imported.opponentName;
+    if (!opponentName) {
+      throw new BadRequestException(
+        `Unable to parse opponent for event ${imported.uid}`,
+      );
+    }
+
+    const externalReference = `${source.provider}:${opponentName}`;
+    const existing = await this.teamRepository.findOne({
+      where: { sourceType: SourceType.EXTERNAL, externalReference },
+    });
+    if (existing) {
+      return existing;
+    }
+
+    return this.teamRepository.save(
+      this.teamRepository.create({
+        name: opponentName,
+        isManaged: false,
+        sourceType: SourceType.EXTERNAL,
+        externalReference,
+        isActive: true,
+      }),
+    );
+  }
+
+  private async resolveGameFormat(teamId: string): Promise<GameFormat> {
+    const config = await this.teamConfigurationRepository.findOne({
+      where: { teamId },
+      relations: { defaultGameFormat: true },
+    });
+    if (config?.defaultGameFormat) {
+      return config.defaultGameFormat;
+    }
+    if (config?.defaultGameFormatId) {
+      const format = await this.gameFormatRepository.findOne({
+        where: { id: config.defaultGameFormatId },
+      });
+      if (format) {
+        return format;
+      }
+    }
+
+    const fallback = await this.gameFormatRepository.findOne({
+      where: { name: '11v11' },
+    });
+    if (!fallback) {
+      throw new NotFoundException(
+        'No default game format found for imported game',
+      );
+    }
+
+    return fallback;
+  }
+
+  private async getTeam(teamId: string): Promise<Team> {
+    const team = await this.teamRepository.findOne({ where: { id: teamId } });
+    if (!team) {
+      throw new NotFoundException(`Team with ID "${teamId}" not found`);
+    }
+
+    return team;
+  }
+
+  private buildGameNotes(imported: ImportedCalendarGame): string | undefined {
+    const notes = [
+      imported.description,
+      imported.arrivalTime ? `Arrival: ${imported.arrivalTime}` : undefined,
+      imported.uniform ? `Uniform: ${imported.uniform}` : undefined,
+      `Imported from calendar UID: ${imported.uid}`,
+    ].filter(Boolean);
+
+    return notes.length > 0 ? notes.join('\n\n') : undefined;
+  }
+
+  private durationMinutes(
+    imported: ImportedCalendarGame,
+    fallback?: number,
+  ): number | undefined {
+    if (imported.endsAt) {
+      return Math.max(
+        1,
+        Math.round(
+          (imported.endsAt.getTime() - imported.startsAt.getTime()) / 60_000,
+        ),
+      );
+    }
+
+    return fallback;
+  }
+
+  private toGameStatus(status: ImportedCalendarGame['status']): GameStatus {
+    return status === 'CANCELLED' ? GameStatus.CANCELLED : GameStatus.SCHEDULED;
+  }
+
+  private validateFeedUrl(feedUrl: string): void {
+    let parsed: URL;
+    try {
+      parsed = new URL(feedUrl);
+    } catch {
+      throw new BadRequestException('Calendar feed URL must be a valid URL');
+    }
+
+    if (!['http:', 'https:'].includes(parsed.protocol)) {
+      throw new BadRequestException('Calendar feed URL must use HTTP or HTTPS');
+    }
+  }
+}

--- a/apps/soccer-stats/api/src/modules/calendar-sync/calendar-sync.service.ts
+++ b/apps/soccer-stats/api/src/modules/calendar-sync/calendar-sync.service.ts
@@ -34,6 +34,8 @@ export interface CalendarSyncResult {
 
 @Injectable()
 export class CalendarSyncService {
+  private readonly activeSourceSyncs = new Set<string>();
+
   constructor(
     @InjectRepository(CalendarSource)
     private readonly calendarSourceRepository: Repository<CalendarSource>,
@@ -120,6 +122,12 @@ export class CalendarSyncService {
       return { sourceId, created: 0, updated: 0, skipped: 0, errors: [] };
     }
 
+    if (this.activeSourceSyncs.has(sourceId)) {
+      return { sourceId, created: 0, updated: 0, skipped: 1, errors: [] };
+    }
+
+    this.activeSourceSyncs.add(sourceId);
+
     const result: CalendarSyncResult = {
       sourceId,
       created: 0,
@@ -161,6 +169,8 @@ export class CalendarSyncService {
         error instanceof Error ? error.message : String(error);
       await this.calendarSourceRepository.save(source);
       throw error;
+    } finally {
+      this.activeSourceSyncs.delete(sourceId);
     }
   }
 
@@ -169,7 +179,7 @@ export class CalendarSyncService {
     const response = await axios.get<string>(feedUrl, {
       responseType: 'text',
       timeout: 15_000,
-      maxRedirects: 3,
+      maxRedirects: 0,
     });
 
     return response.data;
@@ -376,8 +386,16 @@ export class CalendarSyncService {
       throw new BadRequestException('Calendar feed URL must be a valid URL');
     }
 
-    if (!['http:', 'https:'].includes(parsed.protocol)) {
-      throw new BadRequestException('Calendar feed URL must use HTTP or HTTPS');
+    if (parsed.protocol !== 'https:') {
+      throw new BadRequestException(
+        'PlayMetrics calendar feed URL must use HTTPS',
+      );
+    }
+
+    if (parsed.hostname !== 'calendar.playmetrics.com') {
+      throw new BadRequestException(
+        'PlayMetrics calendar feed URL must use calendar.playmetrics.com',
+      );
     }
   }
 }

--- a/apps/soccer-stats/api/src/modules/calendar-sync/dto/calendar-sync-result.type.ts
+++ b/apps/soccer-stats/api/src/modules/calendar-sync/dto/calendar-sync-result.type.ts
@@ -1,0 +1,19 @@
+import { Field, ID, Int, ObjectType } from '@nestjs/graphql';
+
+@ObjectType()
+export class CalendarSyncResultType {
+  @Field(() => ID)
+  sourceId!: string;
+
+  @Field(() => Int)
+  created!: number;
+
+  @Field(() => Int)
+  updated!: number;
+
+  @Field(() => Int)
+  skipped!: number;
+
+  @Field(() => [String])
+  errors!: string[];
+}

--- a/apps/soccer-stats/api/src/modules/calendar-sync/dto/create-calendar-source.input.ts
+++ b/apps/soccer-stats/api/src/modules/calendar-sync/dto/create-calendar-source.input.ts
@@ -1,0 +1,24 @@
+import { Field, ID, InputType } from '@nestjs/graphql';
+import { IsBoolean, IsEnum, IsOptional, IsUrl, IsUUID } from 'class-validator';
+
+import { CalendarProvider } from '../../../entities/calendar-source.entity';
+
+@InputType()
+export class CreateCalendarSourceInput {
+  @Field(() => ID)
+  @IsUUID()
+  teamId!: string;
+
+  @Field(() => CalendarProvider, { defaultValue: CalendarProvider.PLAYMETRICS })
+  @IsEnum(CalendarProvider)
+  provider!: CalendarProvider;
+
+  @Field()
+  @IsUrl({ require_protocol: true })
+  feedUrl!: string;
+
+  @Field({ nullable: true })
+  @IsOptional()
+  @IsBoolean()
+  enabled?: boolean;
+}

--- a/apps/soccer-stats/api/src/modules/calendar-sync/playmetrics-ics-parser.service.spec.ts
+++ b/apps/soccer-stats/api/src/modules/calendar-sync/playmetrics-ics-parser.service.spec.ts
@@ -1,0 +1,72 @@
+import { PlayMetricsIcsParserService } from './playmetrics-ics-parser.service';
+
+const gamesCalendarIcs = `BEGIN:VCALENDAR
+PRODID:-//PlayMetrics//EN
+VERSION:2.0
+TZID:America/Los_Angeles
+X-WR-CALNAME:BU12 Select Airey Games
+X-PUBLISHED-TTL:PT1H
+BEGIN:VEVENT
+UID:Game_4494939
+DTSTAMP:20260712T163101Z
+CREATED:20260706T190035Z
+LAST-MODIFIED:20260706T191149Z
+SEQUENCE:1783365109
+DTSTART;TZID=America/Los_Angeles:20260710T150000
+DTEND;TZID=America/Los_Angeles:20260710T160000
+SUMMARY:BU12 Select Airey - Game
+DESCRIPTION:BU12 Select Airey at Northshore Select SC BU12C (Cornucopia Game #1)\\nArrive by 2:30 PM\\nUniform: Black Jersey\\, Black Shorts\\, Black Socks\\nNorth Green River Park #4
+LOCATION:26352 Green River Rd\\, Kent\\, WA 98030
+STATUS:CONFIRMED
+URL:https://playmetrics.com
+END:VEVENT
+END:VCALENDAR`;
+
+describe('PlayMetricsIcsParserService', () => {
+  let service: PlayMetricsIcsParserService;
+
+  beforeEach(() => {
+    service = new PlayMetricsIcsParserService();
+  });
+
+  it('parses PlayMetrics game events with timezone-aware dates and structured details', () => {
+    const result = service.parse(gamesCalendarIcs);
+
+    expect(result.calendarName).toBe('BU12 Select Airey Games');
+    expect(result.refreshTtl).toBe('PT1H');
+    expect(result.games).toHaveLength(1);
+    expect(result.games[0]).toMatchObject({
+      uid: 'Game_4494939',
+      sequence: 1783365109,
+      summary: 'BU12 Select Airey - Game',
+      location: '26352 Green River Rd, Kent, WA 98030',
+      status: 'CONFIRMED',
+      managedTeamName: 'BU12 Select Airey',
+      opponentName: 'Northshore Select SC BU12C',
+      homeTeamName: 'Northshore Select SC BU12C',
+      awayTeamName: 'BU12 Select Airey',
+      arrivalTime: '2:30 PM',
+      uniform: 'Black Jersey, Black Shorts, Black Socks',
+    });
+    expect(result.games[0].startsAt.toISOString()).toBe(
+      '2026-07-10T22:00:00.000Z',
+    );
+    expect(result.games[0].endsAt?.toISOString()).toBe(
+      '2026-07-10T23:00:00.000Z',
+    );
+    expect(result.games[0].lastModified?.toISOString()).toBe(
+      '2026-07-06T19:11:49.000Z',
+    );
+  });
+
+  it('ignores non-game events from a full team calendar feed', () => {
+    const ics = gamesCalendarIcs
+      .replace('UID:Game_4494939', 'UID:Practice_11051396')
+      .replace(
+        'SUMMARY:BU12 Select Airey - Game',
+        'SUMMARY:BU12 Select Airey - Practice',
+      );
+
+    expect(service.parse(ics).games).toHaveLength(0);
+  });
+});

--- a/apps/soccer-stats/api/src/modules/calendar-sync/playmetrics-ics-parser.service.spec.ts
+++ b/apps/soccer-stats/api/src/modules/calendar-sync/playmetrics-ics-parser.service.spec.ts
@@ -69,4 +69,13 @@ describe('PlayMetricsIcsParserService', () => {
 
     expect(service.parse(ics).games).toHaveLength(0);
   });
+
+  it('does not emit NaN for malformed sequence values', () => {
+    const ics = gamesCalendarIcs.replace(
+      'SEQUENCE:1783365109',
+      'SEQUENCE:not-a-number',
+    );
+
+    expect(service.parse(ics).games[0].sequence).toBeUndefined();
+  });
 });

--- a/apps/soccer-stats/api/src/modules/calendar-sync/playmetrics-ics-parser.service.ts
+++ b/apps/soccer-stats/api/src/modules/calendar-sync/playmetrics-ics-parser.service.ts
@@ -1,0 +1,348 @@
+import { Injectable } from '@nestjs/common';
+
+export type ImportedCalendarGameStatus =
+  | 'CONFIRMED'
+  | 'CANCELLED'
+  | 'TENTATIVE';
+
+export interface ImportedCalendarGame {
+  uid: string;
+  sequence?: number;
+  created?: Date;
+  lastModified?: Date;
+  startsAt: Date;
+  endsAt?: Date;
+  summary: string;
+  description?: string;
+  location?: string;
+  status: ImportedCalendarGameStatus;
+  managedTeamName?: string;
+  opponentName?: string;
+  homeTeamName?: string;
+  awayTeamName?: string;
+  arrivalTime?: string;
+  uniform?: string;
+}
+
+export interface ParsedCalendarFeed {
+  calendarName?: string;
+  refreshTtl?: string;
+  timezone?: string;
+  games: ImportedCalendarGame[];
+}
+
+interface IcsProperty {
+  name: string;
+  params: Record<string, string>;
+  value: string;
+}
+
+@Injectable()
+export class PlayMetricsIcsParserService {
+  parse(ics: string): ParsedCalendarFeed {
+    const unfolded = this.unfoldLines(ics);
+    const calendarProps = this.parseProperties(this.calendarLines(unfolded));
+    const timezone =
+      this.getValue(calendarProps, 'X-WR-TIMEZONE') ??
+      this.getValue(calendarProps, 'TZID');
+
+    return {
+      calendarName: this.getValue(calendarProps, 'X-WR-CALNAME'),
+      refreshTtl: this.getValue(calendarProps, 'X-PUBLISHED-TTL'),
+      timezone,
+      games: this.eventBlocks(unfolded)
+        .map((eventLines) => this.parseEvent(eventLines, timezone))
+        .filter((event): event is ImportedCalendarGame => event !== null),
+    };
+  }
+
+  private parseEvent(
+    eventLines: string[],
+    defaultTimezone?: string,
+  ): ImportedCalendarGame | null {
+    const props = this.parseProperties(eventLines);
+    const uid = this.getValue(props, 'UID');
+    const summary = this.getValue(props, 'SUMMARY');
+
+    if (!uid || !summary || !this.isGameEvent(uid, summary)) {
+      return null;
+    }
+
+    const startsAtProp = this.getProperty(props, 'DTSTART');
+    if (!startsAtProp) {
+      return null;
+    }
+
+    const description = this.getValue(props, 'DESCRIPTION');
+    const teamNames = description
+      ? this.extractTeamNames(description, summary)
+      : {};
+    const status = (this.getValue(props, 'STATUS') ??
+      'CONFIRMED') as ImportedCalendarGameStatus;
+
+    return {
+      uid,
+      sequence: this.parseNumber(this.getValue(props, 'SEQUENCE')),
+      created: this.parseDateProperty(this.getProperty(props, 'CREATED')),
+      lastModified: this.parseDateProperty(
+        this.getProperty(props, 'LAST-MODIFIED'),
+      ),
+      startsAt: this.parseDateProperty(startsAtProp, defaultTimezone) as Date,
+      endsAt: this.parseDateProperty(
+        this.getProperty(props, 'DTEND'),
+        defaultTimezone,
+      ),
+      summary,
+      description,
+      location: this.getValue(props, 'LOCATION'),
+      status,
+      ...teamNames,
+      arrivalTime: description
+        ? this.extractArrivalTime(description)
+        : undefined,
+      uniform: description ? this.extractUniform(description) : undefined,
+    };
+  }
+
+  private unfoldLines(ics: string): string[] {
+    return ics
+      .replace(/\r\n/g, '\n')
+      .replace(/\r/g, '\n')
+      .split('\n')
+      .reduce<string[]>((lines, line) => {
+        if (
+          (line.startsWith(' ') || line.startsWith('\t')) &&
+          lines.length > 0
+        ) {
+          lines[lines.length - 1] += line.slice(1);
+        } else if (line.trim().length > 0) {
+          lines.push(line);
+        }
+        return lines;
+      }, []);
+  }
+
+  private eventBlocks(lines: string[]): string[][] {
+    const blocks: string[][] = [];
+    let current: string[] | null = null;
+
+    for (const line of lines) {
+      if (line === 'BEGIN:VEVENT') {
+        current = [];
+        continue;
+      }
+      if (line === 'END:VEVENT') {
+        if (current) {
+          blocks.push(current);
+        }
+        current = null;
+        continue;
+      }
+      if (current) {
+        current.push(line);
+      }
+    }
+
+    return blocks;
+  }
+
+  private calendarLines(lines: string[]): string[] {
+    const calendarLines: string[] = [];
+    let inEvent = false;
+
+    for (const line of lines) {
+      if (line === 'BEGIN:VEVENT') {
+        inEvent = true;
+        continue;
+      }
+      if (line === 'END:VEVENT') {
+        inEvent = false;
+        continue;
+      }
+      if (!inEvent && !line.startsWith('BEGIN:') && !line.startsWith('END:')) {
+        calendarLines.push(line);
+      }
+    }
+
+    return calendarLines;
+  }
+
+  private parseProperties(lines: string[]): IcsProperty[] {
+    return lines.map((line) => {
+      const separatorIndex = line.indexOf(':');
+      const nameAndParams =
+        separatorIndex >= 0 ? line.slice(0, separatorIndex) : line;
+      const value = separatorIndex >= 0 ? line.slice(separatorIndex + 1) : '';
+      const [rawName, ...rawParams] = nameAndParams.split(';');
+      const params = rawParams.reduce<Record<string, string>>((acc, param) => {
+        const [key, paramValue] = param.split('=');
+        if (key && paramValue) {
+          acc[key.toUpperCase()] = paramValue;
+        }
+        return acc;
+      }, {});
+
+      return {
+        name: rawName.toUpperCase(),
+        params,
+        value: this.unescapeValue(value),
+      };
+    });
+  }
+
+  private getProperty(
+    props: IcsProperty[],
+    name: string,
+  ): IcsProperty | undefined {
+    return props.find((prop) => prop.name === name.toUpperCase());
+  }
+
+  private getValue(props: IcsProperty[], name: string): string | undefined {
+    return this.getProperty(props, name)?.value;
+  }
+
+  private unescapeValue(value: string): string {
+    return value
+      .replace(/\\n/gi, '\n')
+      .replace(/\\,/g, ',')
+      .replace(/\\;/g, ';')
+      .replace(/\\\\/g, '\\')
+      .trim();
+  }
+
+  private isGameEvent(uid: string, summary: string): boolean {
+    return uid.startsWith('Game_') || /\b-\s*Game\b/i.test(summary);
+  }
+
+  private parseDateProperty(
+    property?: IcsProperty,
+    defaultTimezone?: string,
+  ): Date | undefined {
+    if (!property?.value) {
+      return undefined;
+    }
+
+    const value = property.value;
+    if (/^\d{8}T\d{6}Z$/.test(value)) {
+      return new Date(
+        `${value.slice(0, 4)}-${value.slice(4, 6)}-${value.slice(6, 8)}T${value.slice(9, 11)}:${value.slice(11, 13)}:${value.slice(13, 15)}.000Z`,
+      );
+    }
+
+    if (/^\d{8}T\d{6}$/.test(value)) {
+      return this.zonedLocalDateTimeToUtc(
+        value,
+        property.params.TZID ?? defaultTimezone,
+      );
+    }
+
+    if (/^\d{8}$/.test(value)) {
+      return this.zonedLocalDateTimeToUtc(
+        `${value}T000000`,
+        property.params.TZID ?? defaultTimezone,
+      );
+    }
+
+    return new Date(value);
+  }
+
+  private zonedLocalDateTimeToUtc(value: string, timezone = 'UTC'): Date {
+    const year = Number(value.slice(0, 4));
+    const month = Number(value.slice(4, 6));
+    const day = Number(value.slice(6, 8));
+    const hour = Number(value.slice(9, 11));
+    const minute = Number(value.slice(11, 13));
+    const second = Number(value.slice(13, 15));
+    const utcGuess = new Date(
+      Date.UTC(year, month - 1, day, hour, minute, second),
+    );
+    const offsetMinutes = this.getTimezoneOffsetMinutes(utcGuess, timezone);
+
+    return new Date(utcGuess.getTime() - offsetMinutes * 60_000);
+  }
+
+  private getTimezoneOffsetMinutes(date: Date, timezone: string): number {
+    if (timezone === 'UTC') {
+      return 0;
+    }
+
+    const parts = new Intl.DateTimeFormat('en-US', {
+      timeZone: timezone,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      hourCycle: 'h23',
+    }).formatToParts(date);
+    const values = Object.fromEntries(
+      parts.map((part) => [part.type, part.value]),
+    );
+    const zonedAsUtc = Date.UTC(
+      Number(values.year),
+      Number(values.month) - 1,
+      Number(values.day),
+      Number(values.hour),
+      Number(values.minute),
+      Number(values.second),
+    );
+
+    return (zonedAsUtc - date.getTime()) / 60_000;
+  }
+
+  private extractTeamNames(
+    description: string,
+    summary: string,
+  ): Partial<ImportedCalendarGame> {
+    const firstLine = description.split('\n')[0]?.trim();
+    if (!firstLine) {
+      return {};
+    }
+
+    const matchup = firstLine.match(/^(.+?)\s+at\s+(.+?)(?:\s+\(|$)/i);
+    if (!matchup) {
+      return {};
+    }
+
+    const awayTeamName = matchup[1].trim();
+    const homeTeamName = matchup[2].trim();
+    const managedTeamName =
+      this.extractManagedTeamName(summary, awayTeamName, homeTeamName) ??
+      awayTeamName;
+    const opponentName =
+      managedTeamName === awayTeamName ? homeTeamName : awayTeamName;
+
+    return {
+      managedTeamName,
+      opponentName,
+      homeTeamName,
+      awayTeamName,
+    };
+  }
+
+  private extractManagedTeamName(
+    summary: string,
+    awayTeamName: string,
+    homeTeamName: string,
+  ): string | undefined {
+    const summaryPrefix = summary.split(' - ')[0]?.trim();
+    if (summaryPrefix === awayTeamName || summaryPrefix === homeTeamName) {
+      return summaryPrefix;
+    }
+
+    return undefined;
+  }
+
+  private extractArrivalTime(description: string): string | undefined {
+    return description.match(/Arrive by\s+([^\n]+)/i)?.[1]?.trim();
+  }
+
+  private extractUniform(description: string): string | undefined {
+    return description.match(/Uniform:\s+([^\n]+)/i)?.[1]?.trim();
+  }
+
+  private parseNumber(value?: string): number | undefined {
+    return value ? Number(value) : undefined;
+  }
+}

--- a/apps/soccer-stats/api/src/modules/calendar-sync/playmetrics-ics-parser.service.ts
+++ b/apps/soccer-stats/api/src/modules/calendar-sync/playmetrics-ics-parser.service.ts
@@ -343,6 +343,11 @@ export class PlayMetricsIcsParserService {
   }
 
   private parseNumber(value?: string): number | undefined {
-    return value ? Number(value) : undefined;
+    if (!value) {
+      return undefined;
+    }
+
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : undefined;
   }
 }


### PR DESCRIPTION
## Summary
- add team calendar source and external game mapping persistence
- parse PlayMetrics ICS feeds into scheduled games with opponent teams
- expose GraphQL operations to add/sync calendar sources
- add hourly background sync with TEAM_CALENDAR_SYNC_INTERVAL_MS override

## Test Plan
- pnpm nx test soccer-stats-api --runInBand
- pnpm nx lint soccer-stats-api
- NX_SKIP_NX_CACHE=true pnpm nx build soccer-stats-api

## Notes
- backend/API only; team settings UI can be a follow-up slice
- lint reports pre-existing warnings but exits successfully