### PR TITLE
feat: show soccer stats build info

### DIFF
--- a/apps/soccer-stats/api-infra/src/app-runner.ts
+++ b/apps/soccer-stats/api-infra/src/app-runner.ts
@@ -24,7 +24,7 @@ import {
   databaseUrlSecretArn,
 } from './shared-infra';
 import { clerkSecretKeySecretArn } from './secrets';
-import { image } from './docker';
+import { apiVersion, buildTime, gitSha, image } from './docker';
 
 const autoScalingConfig = new aws.apprunner.AutoScalingConfigurationVersion(
   `${namePrefix}-autoscaling`,
@@ -56,6 +56,9 @@ export const service = new aws.apprunner.Service(
           port: containerPort.toString(),
           runtimeEnvironmentVariables: {
             NODE_ENV: 'production',
+            APP_VERSION: apiVersion,
+            GIT_SHA: gitSha,
+            BUILD_TIME: buildTime,
             PORT: containerPort.toString(),
             CONTAINER_MEMORY_LIMIT_MB: '512',
             DB_SYNCHRONIZE: 'false',

--- a/apps/soccer-stats/api-infra/src/docker.ts
+++ b/apps/soccer-stats/api-infra/src/docker.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
 import * as pulumi from '@pulumi/pulumi';
 import * as aws from '@pulumi/aws';
 import * as docker from '@pulumi/docker-build';
@@ -13,7 +16,17 @@ import { ecrRepositoryUrl } from './shared-infra';
 export const currentRegion = aws.getRegionOutput();
 
 // Git SHA for immutable image tags (from CI or local fallback)
-const gitSha = process.env.GITHUB_SHA?.substring(0, 7) || 'local';
+export const gitSha = process.env.GITHUB_SHA?.substring(0, 7) || 'local';
+export const buildTime = new Date().toISOString();
+export const apiVersion =
+  (
+    JSON.parse(
+      readFileSync(
+        join(workspaceRoot, 'apps/soccer-stats/api/package.json'),
+        'utf8',
+      ),
+    ) as { version?: string }
+  ).version ?? '0.0.1';
 
 // Tag strategy:
 // - Non-prod stacks: :dev, :staging + :abc123 (git sha)
@@ -49,6 +62,9 @@ export const image = new docker.Image(`${namePrefix}-image`, {
   ],
   // Build args if needed
   buildArgs: {
+    APP_VERSION: apiVersion,
+    GIT_SHA: gitSha,
+    BUILD_TIME: buildTime,
     NODE_ENV: 'production',
   },
   // Cache configuration for faster builds

--- a/apps/soccer-stats/api/Dockerfile
+++ b/apps/soccer-stats/api/Dockerfile
@@ -7,10 +7,17 @@
 
 FROM docker.io/node:22-alpine AS production
 
+ARG APP_VERSION=0.0.1
+ARG GIT_SHA=unknown
+ARG BUILD_TIME=unknown
+
 # Set environment variables
 ENV NODE_ENV=production
 ENV HOST=0.0.0.0
 ENV PORT=3333
+ENV APP_VERSION=${APP_VERSION}
+ENV GIT_SHA=${GIT_SHA}
+ENV BUILD_TIME=${BUILD_TIME}
 
 # Enable corepack for pnpm
 RUN corepack enable && corepack prepare pnpm@latest --activate

--- a/apps/soccer-stats/api/src/app/app.controller.spec.ts
+++ b/apps/soccer-stats/api/src/app/app.controller.spec.ts
@@ -19,4 +19,26 @@ describe('AppController', () => {
       expect(appController.getData()).toEqual({ message: 'Hello API' });
     });
   });
+
+  describe('getVersion', () => {
+    it('returns API build metadata from the service', () => {
+      const appController = app.get<AppController>(AppController);
+      const appService = app.get<AppService>(AppService);
+      jest.spyOn(appService, 'getVersion').mockReturnValue({
+        name: 'soccer-stats-api',
+        version: '1.2.3',
+        gitSha: 'abc1234',
+        buildTime: '2026-07-15T02:22:42.000Z',
+        environment: 'production',
+      });
+
+      expect(appController.getVersion()).toEqual({
+        name: 'soccer-stats-api',
+        version: '1.2.3',
+        gitSha: 'abc1234',
+        buildTime: '2026-07-15T02:22:42.000Z',
+        environment: 'production',
+      });
+    });
+  });
 });

--- a/apps/soccer-stats/api/src/app/app.controller.ts
+++ b/apps/soccer-stats/api/src/app/app.controller.ts
@@ -1,6 +1,7 @@
 import { Controller, Get } from '@nestjs/common';
 
 import { AppService, HealthStatus, ProcessMetrics } from './app.service';
+import type { BuildInfo } from './app.service';
 
 @Controller()
 export class AppController {
@@ -18,6 +19,14 @@ export class AppController {
   @Get('health')
   getHealth(): HealthStatus {
     return this.appService.getHealth();
+  }
+
+  /**
+   * Build metadata endpoint for verifying the deployed API artifact.
+   */
+  @Get('version')
+  getVersion(): BuildInfo {
+    return this.appService.getVersion();
   }
 
   /**

--- a/apps/soccer-stats/api/src/app/app.service.spec.ts
+++ b/apps/soccer-stats/api/src/app/app.service.spec.ts
@@ -9,6 +9,12 @@ import { AppService } from './app.service';
 
 describe('AppService', () => {
   let service: AppService;
+  const originalEnv = {
+    APP_VERSION: process.env['APP_VERSION'],
+    GIT_SHA: process.env['GIT_SHA'],
+    BUILD_TIME: process.env['BUILD_TIME'],
+    NODE_ENV: process.env['NODE_ENV'],
+  };
 
   beforeAll(async () => {
     const app = await Test.createTestingModule({
@@ -24,8 +30,51 @@ describe('AppService', () => {
     });
   });
 
+  describe('getVersion', () => {
+    afterEach(() => {
+      for (const [key, value] of Object.entries(originalEnv)) {
+        if (value === undefined) {
+          delete process.env[key];
+        } else {
+          process.env[key] = value;
+        }
+      }
+    });
+
+    it('returns build metadata from environment variables', () => {
+      process.env['APP_VERSION'] = '1.2.3';
+      process.env['GIT_SHA'] = 'abc1234';
+      process.env['BUILD_TIME'] = '2026-07-15T02:22:42.000Z';
+      process.env['NODE_ENV'] = 'production';
+
+      expect(service.getVersion()).toEqual({
+        name: 'soccer-stats-api',
+        version: '1.2.3',
+        gitSha: 'abc1234',
+        buildTime: '2026-07-15T02:22:42.000Z',
+        environment: 'production',
+      });
+    });
+
+    it('uses safe fallback values when build metadata is unavailable', () => {
+      delete process.env['APP_VERSION'];
+      delete process.env['GIT_SHA'];
+      delete process.env['BUILD_TIME'];
+      delete process.env['NODE_ENV'];
+
+      expect(service.getVersion()).toEqual({
+        name: 'soccer-stats-api',
+        version: '0.0.1',
+        gitSha: 'unknown',
+        buildTime: 'unknown',
+        environment: 'unknown',
+      });
+    });
+  });
+
   describe('getHealth', () => {
-    const originalContainerMemoryLimit = process.env['CONTAINER_MEMORY_LIMIT_MB'];
+    const originalContainerMemoryLimit =
+      process.env['CONTAINER_MEMORY_LIMIT_MB'];
 
     afterEach(() => {
       if (originalContainerMemoryLimit === undefined) {

--- a/apps/soccer-stats/api/src/app/app.service.ts
+++ b/apps/soccer-stats/api/src/app/app.service.ts
@@ -28,6 +28,17 @@ export interface HealthStatus {
 }
 
 /**
+ * Build metadata for identifying the deployed API artifact.
+ */
+export interface BuildInfo {
+  name: string;
+  version: string;
+  gitSha: string;
+  buildTime: string;
+  environment: string;
+}
+
+/**
  * Detailed process metrics response
  */
 export interface ProcessMetrics {
@@ -61,6 +72,16 @@ export class AppService {
 
   getData(): { message: string } {
     return { message: 'Hello API' };
+  }
+
+  getVersion(): BuildInfo {
+    return {
+      name: 'soccer-stats-api',
+      version: process.env['APP_VERSION'] || '0.0.1',
+      gitSha: process.env['GIT_SHA'] || 'unknown',
+      buildTime: process.env['BUILD_TIME'] || 'unknown',
+      environment: process.env['NODE_ENV'] || 'unknown',
+    };
   }
 
   /**

--- a/apps/soccer-stats/ui/src/app/build-info-globals.d.ts
+++ b/apps/soccer-stats/ui/src/app/build-info-globals.d.ts
@@ -1,0 +1,4 @@
+declare const __UI_VERSION__: string;
+declare const __GIT_SHA__: string;
+declare const __BUILD_TIME__: string;
+declare const __APP_ENVIRONMENT__: string;

--- a/apps/soccer-stats/ui/src/app/pages/settings.page.spec.tsx
+++ b/apps/soccer-stats/ui/src/app/pages/settings.page.spec.tsx
@@ -1,0 +1,49 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { SettingsPage } from './settings.page';
+
+vi.mock('../services/build-info.service', async () => {
+  const actual = await vi.importActual<
+    typeof import('../services/build-info.service')
+  >('../services/build-info.service');
+
+  return {
+    ...actual,
+    getUiBuildInfo: () => ({
+      name: 'soccer-stats-ui',
+      version: '0.0.0',
+      gitSha: 'ui12345',
+      buildTime: '2026-07-15T02:22:42.000Z',
+      environment: 'production',
+    }),
+    fetchApiBuildInfo: vi.fn().mockResolvedValue({
+      name: 'soccer-stats-api',
+      version: '0.0.1',
+      gitSha: 'api12345',
+      buildTime: '2026-07-15T02:18:42.000Z',
+      environment: 'production',
+    }),
+  };
+});
+
+describe('SettingsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows UI and API build information', async () => {
+    render(<SettingsPage />);
+
+    expect(screen.getByText('Build Info')).toBeTruthy();
+    expect(screen.getByText('UI')).toBeTruthy();
+    expect(screen.getByText('0.0.0')).toBeTruthy();
+    expect(screen.getByText('ui12345')).toBeTruthy();
+
+    await waitFor(() => {
+      expect(screen.getByText('API')).toBeTruthy();
+      expect(screen.getByText('0.0.1')).toBeTruthy();
+      expect(screen.getByText('api12345')).toBeTruthy();
+    });
+  });
+});

--- a/apps/soccer-stats/ui/src/app/pages/settings.page.spec.tsx
+++ b/apps/soccer-stats/ui/src/app/pages/settings.page.spec.tsx
@@ -46,4 +46,24 @@ describe('SettingsPage', () => {
       expect(screen.getByText('api12345')).toBeTruthy();
     });
   });
+
+  it('uses touch-friendly targets for settings controls', async () => {
+    render(<SettingsPage />);
+
+    for (const select of screen.getAllByRole('combobox')) {
+      expect(select.className).toContain('min-h-[44px]');
+      expect(select.className).toContain('min-w-[44px]');
+    }
+
+    expect(
+      screen.getByRole('button', { name: 'Export Game Data' }).className,
+    ).toContain('min-h-[44px]');
+    expect(
+      screen.getByRole('button', { name: 'Clear All Data' }).className,
+    ).toContain('min-h-[44px]');
+
+    await waitFor(() => {
+      expect(screen.getByText('api12345')).toBeTruthy();
+    });
+  });
 });

--- a/apps/soccer-stats/ui/src/app/pages/settings.page.tsx
+++ b/apps/soccer-stats/ui/src/app/pages/settings.page.tsx
@@ -1,19 +1,124 @@
+import { useEffect, useState } from 'react';
+
+import {
+  fetchApiBuildInfo,
+  getUiBuildInfo,
+} from '../services/build-info.service';
+import type { BuildInfo } from '../services/build-info.service';
+
+function formatBuildTime(buildTime: string): string {
+  if (buildTime === 'unknown') {
+    return 'unknown';
+  }
+
+  const date = new Date(buildTime);
+  if (Number.isNaN(date.getTime())) {
+    return buildTime;
+  }
+
+  return date.toLocaleString(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  });
+}
+
+function BuildInfoCard({ label, info }: { label: string; info: BuildInfo }) {
+  return (
+    <div className="rounded-md border border-gray-200 bg-gray-50 p-4">
+      <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-700">
+        {label}
+      </h3>
+      <dl className="mt-3 grid grid-cols-1 gap-2 text-sm sm:grid-cols-2">
+        <div>
+          <dt className="text-gray-500">Version</dt>
+          <dd className="font-mono text-gray-900">{info.version}</dd>
+        </div>
+        <div>
+          <dt className="text-gray-500">Git SHA</dt>
+          <dd className="font-mono text-gray-900">{info.gitSha}</dd>
+        </div>
+        <div>
+          <dt className="text-gray-500">Built</dt>
+          <dd className="font-mono text-gray-900">
+            {formatBuildTime(info.buildTime)}
+          </dd>
+        </div>
+        <div>
+          <dt className="text-gray-500">Environment</dt>
+          <dd className="font-mono text-gray-900">{info.environment}</dd>
+        </div>
+      </dl>
+    </div>
+  );
+}
+
+function BuildInfoPanel() {
+  const [apiBuildInfo, setApiBuildInfo] = useState<BuildInfo | null>(null);
+  const [apiBuildInfoError, setApiBuildInfoError] = useState<string | null>(
+    null,
+  );
+  const uiBuildInfo = getUiBuildInfo();
+
+  useEffect(() => {
+    let isMounted = true;
+
+    fetchApiBuildInfo()
+      .then((info) => {
+        if (isMounted) {
+          setApiBuildInfo(info);
+        }
+      })
+      .catch((error: unknown) => {
+        if (isMounted) {
+          setApiBuildInfoError(
+            error instanceof Error ? error.message : String(error),
+          );
+        }
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  return (
+    <div>
+      <h2 className="mb-4 text-lg font-semibold text-gray-900">Build Info</h2>
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <BuildInfoCard label="UI" info={uiBuildInfo} />
+        {apiBuildInfo ? (
+          <BuildInfoCard label="API" info={apiBuildInfo} />
+        ) : (
+          <div className="rounded-md border border-gray-200 bg-gray-50 p-4">
+            <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-700">
+              API
+            </h3>
+            <p className="mt-3 text-sm text-gray-600">
+              {apiBuildInfoError ?? 'Loading API build info…'}
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
 /**
  * Application settings page
  */
 export const SettingsPage = () => {
   return (
-    <div className="bg-white rounded-lg shadow-lg p-6">
+    <div className="rounded-lg bg-white p-6 shadow-lg">
       <div className="mb-6">
         <h1 className="text-3xl font-bold text-gray-900">Settings</h1>
-        <p className="text-gray-600 mt-2">
+        <p className="mt-2 text-gray-600">
           Configure application preferences and defaults
         </p>
       </div>
 
       <div className="space-y-6">
         <div className="border-b border-gray-200 pb-6">
-          <h2 className="text-lg font-semibold text-gray-900 mb-4">
+          <h2 className="mb-4 text-lg font-semibold text-gray-900">
             Game Settings
           </h2>
           <div className="space-y-4">
@@ -26,7 +131,7 @@ export const SettingsPage = () => {
                   Default length for new games
                 </p>
               </div>
-              <select className="border border-gray-300 rounded-md px-3 py-2">
+              <select className="rounded-md border border-gray-300 px-3 py-2">
                 <option value="90">90 minutes</option>
                 <option value="80">80 minutes</option>
                 <option value="70">70 minutes</option>
@@ -48,7 +153,7 @@ export const SettingsPage = () => {
         </div>
 
         <div className="border-b border-gray-200 pb-6">
-          <h2 className="text-lg font-semibold text-gray-900 mb-4">
+          <h2 className="mb-4 text-lg font-semibold text-gray-900">
             Display Settings
           </h2>
           <div className="space-y-4">
@@ -61,7 +166,7 @@ export const SettingsPage = () => {
                   Choose your preferred color scheme
                 </p>
               </div>
-              <select className="border border-gray-300 rounded-md px-3 py-2">
+              <select className="rounded-md border border-gray-300 px-3 py-2">
                 <option value="light">Light</option>
                 <option value="dark">Dark</option>
                 <option value="auto">Auto</option>
@@ -70,19 +175,21 @@ export const SettingsPage = () => {
           </div>
         </div>
 
-        <div>
-          <h2 className="text-lg font-semibold text-gray-900 mb-4">
+        <div className="border-b border-gray-200 pb-6">
+          <h2 className="mb-4 text-lg font-semibold text-gray-900">
             Data Management
           </h2>
           <div className="space-y-4">
-            <button className="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition-colors">
+            <button className="rounded-md bg-blue-600 px-4 py-2 text-white transition-colors hover:bg-blue-700">
               Export Game Data
             </button>
-            <button className="bg-red-600 text-white px-4 py-2 rounded-md hover:bg-red-700 transition-colors ml-3">
+            <button className="ml-3 rounded-md bg-red-600 px-4 py-2 text-white transition-colors hover:bg-red-700">
               Clear All Data
             </button>
           </div>
         </div>
+
+        <BuildInfoPanel />
       </div>
     </div>
   );

--- a/apps/soccer-stats/ui/src/app/pages/settings.page.tsx
+++ b/apps/soccer-stats/ui/src/app/pages/settings.page.tsx
@@ -131,7 +131,7 @@ export const SettingsPage = () => {
                   Default length for new games
                 </p>
               </div>
-              <select className="rounded-md border border-gray-300 px-3 py-2">
+              <select className="min-h-[44px] min-w-[44px] rounded-md border border-gray-300 px-3 py-2">
                 <option value="90">90 minutes</option>
                 <option value="80">80 minutes</option>
                 <option value="70">70 minutes</option>
@@ -166,7 +166,7 @@ export const SettingsPage = () => {
                   Choose your preferred color scheme
                 </p>
               </div>
-              <select className="rounded-md border border-gray-300 px-3 py-2">
+              <select className="min-h-[44px] min-w-[44px] rounded-md border border-gray-300 px-3 py-2">
                 <option value="light">Light</option>
                 <option value="dark">Dark</option>
                 <option value="auto">Auto</option>
@@ -180,10 +180,10 @@ export const SettingsPage = () => {
             Data Management
           </h2>
           <div className="space-y-4">
-            <button className="rounded-md bg-blue-600 px-4 py-2 text-white transition-colors hover:bg-blue-700">
+            <button className="min-h-[44px] min-w-[44px] rounded-md bg-blue-600 px-4 py-3 text-white transition-colors hover:bg-blue-700">
               Export Game Data
             </button>
-            <button className="ml-3 rounded-md bg-red-600 px-4 py-2 text-white transition-colors hover:bg-red-700">
+            <button className="ml-3 min-h-[44px] min-w-[44px] rounded-md bg-red-600 px-4 py-3 text-white transition-colors hover:bg-red-700">
               Clear All Data
             </button>
           </div>

--- a/apps/soccer-stats/ui/src/app/services/build-info.service.spec.ts
+++ b/apps/soccer-stats/ui/src/app/services/build-info.service.spec.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { fetchApiBuildInfo, getUiBuildInfo } from './build-info.service';
+
+describe('Build info service', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.stubEnv('VITE_API_URL', '');
+  });
+
+  it('returns UI build metadata embedded at build time', () => {
+    expect(getUiBuildInfo()).toMatchObject({
+      name: 'soccer-stats-ui',
+      version: expect.any(String),
+      gitSha: expect.any(String),
+      buildTime: expect.any(String),
+      environment: expect.any(String),
+    });
+  });
+
+  it('fetches API build metadata through the same-origin API route', async () => {
+    const apiBuildInfo = {
+      name: 'soccer-stats-api',
+      version: '1.2.3',
+      gitSha: 'abc1234',
+      buildTime: '2026-07-15T02:22:42.000Z',
+      environment: 'production',
+    };
+
+    global.fetch = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(apiBuildInfo),
+      } as Response),
+    );
+
+    await expect(fetchApiBuildInfo()).resolves.toEqual(apiBuildInfo);
+    expect(fetch).toHaveBeenCalledWith('/api/version');
+  });
+
+  it('fetches API build metadata from VITE_API_URL when configured', async () => {
+    vi.stubEnv('VITE_API_URL', 'https://api.example.com');
+    global.fetch = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({}),
+      } as Response),
+    );
+
+    await fetchApiBuildInfo();
+
+    expect(fetch).toHaveBeenCalledWith('https://api.example.com/api/version');
+  });
+});

--- a/apps/soccer-stats/ui/src/app/services/build-info.service.ts
+++ b/apps/soccer-stats/ui/src/app/services/build-info.service.ts
@@ -1,0 +1,33 @@
+import { API_PREFIX, getApiUrl } from './environment';
+
+export interface BuildInfo {
+  name: string;
+  version: string;
+  gitSha: string;
+  buildTime: string;
+  environment: string;
+}
+
+export function getUiBuildInfo(): BuildInfo {
+  return {
+    name: 'soccer-stats-ui',
+    version: __UI_VERSION__,
+    gitSha: __GIT_SHA__,
+    buildTime: __BUILD_TIME__,
+    environment: __APP_ENVIRONMENT__,
+  };
+}
+
+export async function fetchApiBuildInfo(): Promise<BuildInfo> {
+  const apiUrl = getApiUrl();
+  const versionUrl = `${apiUrl}/${API_PREFIX}/version`;
+  const response = await fetch(versionUrl);
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch API build info: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  return response.json() as Promise<BuildInfo>;
+}

--- a/apps/soccer-stats/ui/vite.config.ts
+++ b/apps/soccer-stats/ui/vite.config.ts
@@ -1,8 +1,35 @@
 /// <reference types='vitest' />
+import { execSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
 import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
+
+const rootPackage = JSON.parse(
+  readFileSync(join(__dirname, '../../../package.json'), 'utf8'),
+) as { version?: string };
+
+function getGitSha(): string {
+  if (process.env['VERCEL_GIT_COMMIT_SHA']) {
+    return process.env['VERCEL_GIT_COMMIT_SHA'].slice(0, 7);
+  }
+
+  if (process.env['GITHUB_SHA']) {
+    return process.env['GITHUB_SHA'].slice(0, 7);
+  }
+
+  try {
+    return execSync('git rev-parse --short HEAD', {
+      cwd: join(__dirname, '../../../'),
+      encoding: 'utf8',
+    }).trim();
+  } catch {
+    return 'local';
+  }
+}
 
 const proxyConfig = {
   '/api': {
@@ -30,6 +57,12 @@ const proxyConfig = {
 export default defineConfig(() => ({
   root: __dirname,
   cacheDir: '../../../node_modules/.vite/apps/soccer-stats',
+  define: {
+    __UI_VERSION__: JSON.stringify(rootPackage.version ?? '0.0.0'),
+    __GIT_SHA__: JSON.stringify(getGitSha()),
+    __BUILD_TIME__: JSON.stringify(new Date().toISOString()),
+    __APP_ENVIRONMENT__: JSON.stringify(process.env['NODE_ENV'] ?? 'unknown'),
+  },
   server: {
     port: 4200,
     host: 'localhost',


### PR DESCRIPTION
## Summary
- add API /api/version metadata endpoint for deployed build details
- embed UI build metadata at Vite build time
- show UI and API version/SHA/build time/environment on the Settings page
- pass API build metadata through Docker/App Runner deployment config

## Test Plan
- pnpm nx test soccer-stats-api --runInBand
- pnpm nx test soccer-stats-ui --run
- pnpm nx build soccer-stats-api
- pnpm nx build soccer-stats-ui
- pnpm nx lint soccer-stats-api
- pnpm nx lint soccer-stats-ui
- git diff --check