### PR TITLE
Fix soccer stats API build info display

### DIFF
--- a/.github/workflows/deploy-soccer-stats.yml
+++ b/.github/workflows/deploy-soccer-stats.yml
@@ -75,15 +75,16 @@ jobs:
       - name: Verify deployment health
         run: |
           for i in $(seq 1 20); do
-            STATUS=$(curl -s -o /dev/null -w '%{http_code}' --max-time 30 "$SOCCER_STATS_SITE_URL/api/health" || true)
-            if [ "$STATUS" = "200" ]; then
-              echo "Health check passed"
+            HEALTH_STATUS=$(curl -s -o /dev/null -w '%{http_code}' --max-time 30 "$SOCCER_STATS_SITE_URL/api/health" || true)
+            VERSION_CONTENT_TYPE=$(curl -s -o /dev/null -w '%{content_type}' --max-time 30 "$SOCCER_STATS_SITE_URL/api/version" || true)
+            if [ "$HEALTH_STATUS" = "200" ] && echo "$VERSION_CONTENT_TYPE" | grep -qi 'application/json'; then
+              echo "Health and version checks passed"
               exit 0
             fi
-            echo "Attempt $i: /api/health returned $STATUS — retrying in 15s (Aurora may be resuming)"
+            echo "Attempt $i: /api/health returned $HEALTH_STATUS; /api/version content-type was ${VERSION_CONTENT_TYPE:-none} — retrying in 15s (Aurora/App Runner may still be updating)"
             sleep 15
           done
-          echo "Health check failed after 5 minutes"
+          echo "Deployment verification failed after 5 minutes"
           exit 1
 
       - name: Record GitHub deployment

--- a/apps/soccer-stats/api/src/app/app.service.spec.ts
+++ b/apps/soccer-stats/api/src/app/app.service.spec.ts
@@ -84,6 +84,21 @@ describe('AppService', () => {
       }
     });
 
+    it('includes API build metadata', () => {
+      process.env['APP_VERSION'] = '1.2.3';
+      process.env['GIT_SHA'] = 'abc1234';
+      process.env['BUILD_TIME'] = '2026-07-15T02:22:42.000Z';
+      process.env['NODE_ENV'] = 'production';
+
+      expect(service.getHealth().build).toEqual({
+        name: 'soccer-stats-api',
+        version: '1.2.3',
+        gitSha: 'abc1234',
+        buildTime: '2026-07-15T02:22:42.000Z',
+        environment: 'production',
+      });
+    });
+
     function createServiceWithMemory(snapshot: MemorySnapshot): AppService {
       const observabilityService: Pick<
         ObservabilityService,

--- a/apps/soccer-stats/api/src/app/app.service.ts
+++ b/apps/soccer-stats/api/src/app/app.service.ts
@@ -24,6 +24,7 @@ export interface HealthStatus {
   status: 'ok' | 'degraded' | 'unhealthy';
   timestamp: string;
   uptime: number;
+  build: BuildInfo;
   memory?: MemoryMetrics;
 }
 
@@ -106,6 +107,7 @@ export class AppService {
         status: 'ok',
         timestamp,
         uptime,
+        build: this.getVersion(),
       };
     }
 
@@ -131,6 +133,7 @@ export class AppService {
       status,
       timestamp,
       uptime,
+      build: this.getVersion(),
       memory: {
         heapUsedMB: snapshot.heapUsedMB,
         heapTotalMB: snapshot.heapTotalMB,

--- a/apps/soccer-stats/ui/src/app/services/build-info.service.spec.ts
+++ b/apps/soccer-stats/ui/src/app/services/build-info.service.spec.ts
@@ -30,6 +30,7 @@ describe('Build info service', () => {
     global.fetch = vi.fn(() =>
       Promise.resolve({
         ok: true,
+        headers: new Headers({ 'content-type': 'application/json' }),
         json: () => Promise.resolve(apiBuildInfo),
       } as Response),
     );
@@ -43,6 +44,7 @@ describe('Build info service', () => {
     global.fetch = vi.fn(() =>
       Promise.resolve({
         ok: true,
+        headers: new Headers({ 'content-type': 'application/json' }),
         json: () => Promise.resolve({}),
       } as Response),
     );
@@ -50,5 +52,32 @@ describe('Build info service', () => {
     await fetchApiBuildInfo();
 
     expect(fetch).toHaveBeenCalledWith('https://api.example.com/api/version');
+  });
+
+  it('falls back to API health metadata when the version route returns HTML', async () => {
+    const apiBuildInfo = {
+      name: 'soccer-stats-api',
+      version: '1.2.3',
+      gitSha: 'abc1234',
+      buildTime: '2026-07-15T02:22:42.000Z',
+      environment: 'production',
+    };
+
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers({ 'content-type': 'text/html' }),
+        text: () => Promise.resolve('<!DOCTYPE html><html></html>'),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: () => Promise.resolve({ build: apiBuildInfo }),
+      } as Response);
+
+    await expect(fetchApiBuildInfo()).resolves.toEqual(apiBuildInfo);
+    expect(fetch).toHaveBeenNthCalledWith(1, '/api/version');
+    expect(fetch).toHaveBeenNthCalledWith(2, '/api/health');
   });
 });

--- a/apps/soccer-stats/ui/src/app/services/build-info.service.ts
+++ b/apps/soccer-stats/ui/src/app/services/build-info.service.ts
@@ -29,5 +29,30 @@ export async function fetchApiBuildInfo(): Promise<BuildInfo> {
     );
   }
 
-  return response.json() as Promise<BuildInfo>;
+  const contentType = response.headers.get('content-type') ?? '';
+  if (contentType.toLowerCase().includes('application/json')) {
+    return response.json() as Promise<BuildInfo>;
+  }
+
+  return fetchApiBuildInfoFromHealth(apiUrl);
+}
+
+async function fetchApiBuildInfoFromHealth(apiUrl: string): Promise<BuildInfo> {
+  const healthUrl = `${apiUrl}/${API_PREFIX}/health`;
+  const response = await fetch(healthUrl);
+
+  if (!response.ok) {
+    throw new Error(
+      `API build info unavailable: /${API_PREFIX}/version returned non-JSON and /${API_PREFIX}/health failed with ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const health = (await response.json()) as { build?: BuildInfo };
+  if (!health.build) {
+    throw new Error(
+      `API build info unavailable: /${API_PREFIX}/version returned non-JSON and /${API_PREFIX}/health did not include build metadata`,
+    );
+  }
+
+  return health.build;
 }


### PR DESCRIPTION
## Summary
- Add API build metadata to the existing /api/health response so the UI has a same-origin fallback when /api/version is rewritten to the SPA shell.
- Make the UI build-info fetcher reject non-JSON /api/version responses instead of surfacing raw JSON parse errors, then fall back to /api/health build metadata.
- Tighten deployment verification so a deployment is not marked healthy unless /api/version returns JSON.

## Verification
- pnpm nx test soccer-stats-api --runInBand --skip-nx-cache
- pnpm nx test soccer-stats-ui --run --skip-nx-cache
- pnpm nx build soccer-stats-api --skip-nx-cache
- pnpm nx build soccer-stats-ui --skip-nx-cache
- pnpm nx lint soccer-stats-api --skip-nx-cache
- pnpm nx lint soccer-stats-ui --skip-nx-cache
- git diff --check

## Root cause
The live /api/version request is currently receiving the SPA index.html from CloudFront/S3 (content-type text/html), so the Settings page attempted to parse HTML as JSON and showed the browser parse error.