### PR TITLE
Fix soccer stats API image deployment

### DIFF
--- a/apps/soccer-stats/api-infra/src/app-runner.ts
+++ b/apps/soccer-stats/api-infra/src/app-runner.ts
@@ -48,9 +48,12 @@ export const service = new aws.apprunner.Service(
       },
       autoDeploymentsEnabled: true,
       imageRepository: {
-        // Reference the stack-tagged image (:dev, :prod, etc.)
-        // App Runner auto-deploys when docker.ts pushes a new image with this tag
-        imageIdentifier: pulumi.interpolate`${ecrRepositoryUrl}:${stack}`,
+        // Use the immutable git-SHA tag so each service update points App Runner
+        // at the exact image pushed by this deploy. The mutable stack tag (:dev,
+        // :prod, etc.) is still pushed for human convenience, but App Runner
+        // may not pull a fresh digest when the imageIdentifier string is
+        // unchanged.
+        imageIdentifier: pulumi.interpolate`${ecrRepositoryUrl}:${gitSha}`,
         imageRepositoryType: 'ECR',
         imageConfiguration: {
           port: containerPort.toString(),


### PR DESCRIPTION
## Summary
- Point App Runner at the immutable git-SHA image tag pushed during the deploy instead of the mutable stack tag.
- Keeps the mutable :dev/:prod tag for convenience, but prevents service updates from restarting against an old image digest.

## Verification
- pnpm nx lint soccer-stats-api-infra --skip-nx-cache
- pnpm nx build soccer-stats-api-infra --skip-nx-cache
- git diff --check

## Context
Deployment #29397355954 pushed a new API image and updated App Runner, but the live API still served the old code: /api/health had no build metadata and /api/version was still rewritten to the SPA shell. The mutable imageIdentifier is the culprit; App Runner needs a changed image identifier to reliably pull the new digest.