### PR TITLE
feat(soccer-stats): polish team pages UX

### DIFF
--- a/apps/soccer-stats/ui/src/app/components/common/protected-route.tsx
+++ b/apps/soccer-stats/ui/src/app/components/common/protected-route.tsx
@@ -17,26 +17,38 @@ export const ProtectedRoute = ({ children }: ProtectedRouteProps) => {
     <>
       <SignedIn>{children}</SignedIn>
       <SignedOut>
-        <div className="flex min-h-[400px] items-center justify-center">
-          <div className="text-center">
-            <div className="mb-4 text-6xl">🔒</div>
-            <h2 className="mb-2 text-2xl font-bold text-gray-900">
-              Authentication Required
-            </h2>
-            <p className="mb-6 text-gray-600">
-              Please sign in to access the Soccer Stats application.
-            </p>
-            <div className="flex justify-center gap-4">
+        <div className="flex min-h-[calc(100vh-5rem)] items-center justify-center px-4 py-12">
+          <div className="w-full max-w-lg overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-xl">
+            <div className="bg-gradient-to-br from-blue-600 via-blue-700 to-slate-950 px-8 py-10 text-center text-white">
+              <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-2xl bg-white/15 text-4xl shadow-inner backdrop-blur">
+                <span role="img" aria-label="Locked">
+                  🔒
+                </span>
+              </div>
+              <h2 className="mt-5 text-3xl font-black tracking-tight">
+                Sign in to continue
+              </h2>
+              <p className="mx-auto mt-3 max-w-sm text-sm leading-6 text-blue-100">
+                Team pages include roster, game, and statistics controls. We
+                keep those behind your account instead of leaving them on the
+                touchline.
+              </p>
+            </div>
+
+            <div className="space-y-4 px-8 py-7">
               <SignInButton>
-                <button className="rounded-md border border-gray-300 px-6 py-3 text-sm font-medium text-gray-600 hover:bg-gray-50 hover:text-gray-900">
+                <button className="flex min-h-[48px] w-full items-center justify-center rounded-xl bg-blue-600 px-5 py-3 text-sm font-bold text-white shadow-sm transition hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2">
                   Sign In
                 </button>
               </SignInButton>
               <SignUpButton>
-                <button className="rounded-md bg-blue-600 px-6 py-3 text-sm font-medium text-white hover:bg-blue-700">
-                  Sign Up
+                <button className="flex min-h-[48px] w-full items-center justify-center rounded-xl border border-slate-300 bg-white px-5 py-3 text-sm font-bold text-slate-700 transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2">
+                  Create Account
                 </button>
               </SignUpButton>
+              <p className="text-center text-xs text-slate-500">
+                Use the same account you use for Soccer Stats.
+              </p>
             </div>
           </div>
         </div>

--- a/apps/soccer-stats/ui/src/app/components/layout/team-layout.tsx
+++ b/apps/soccer-stats/ui/src/app/components/layout/team-layout.tsx
@@ -12,6 +12,12 @@ import {
   TeamResponse,
 } from '../../services/teams-graphql.service';
 
+const fallbackTeamColor = '#2563eb';
+
+function readableTeamColor(color?: string | null) {
+  return color?.trim() || fallbackTeamColor;
+}
+
 /**
  * Layout component that provides common navigation and header for team pages
  */
@@ -20,7 +26,7 @@ export const TeamLayout = () => {
   const navigate = useNavigate();
   const location = useLocation();
 
-  const { data, loading } = useQuery<TeamResponse>(GET_TEAM_BY_ID, {
+  const { data, loading, refetch } = useQuery<TeamResponse>(GET_TEAM_BY_ID, {
     variables: { id: teamId },
     errorPolicy: 'all',
     fetchPolicy: 'cache-and-network',
@@ -30,7 +36,9 @@ export const TeamLayout = () => {
   if (!teamId) {
     return (
       <div className="p-4">
-        <div className="text-red-600">Error: No team ID provided</div>
+        <div className="rounded-xl border border-red-200 bg-red-50 p-4 text-red-700">
+          Error: No team ID provided
+        </div>
       </div>
     );
   }
@@ -38,6 +46,7 @@ export const TeamLayout = () => {
   // TODO: Implement mapServiceTeamToUITeam when migrating to new architecture
   // const team = data?.team ? mapServiceTeamToUITeam(data.team) : null;
   const team = data?.team || null;
+  const teamColor = readableTeamColor(team?.homePrimaryColor);
 
   const tabs = [
     {
@@ -67,112 +76,109 @@ export const TeamLayout = () => {
     },
   ];
 
-  const currentTab = tabs.find((tab) => location.pathname === tab.path);
+  const currentTab = tabs.find(
+    (tab) =>
+      location.pathname === tab.path ||
+      location.pathname.startsWith(`${tab.path}/`),
+  );
 
   return (
-    <div className="mx-auto max-w-6xl p-4 sm:p-6">
-      {/* Header */}
-      <div className="mb-6 rounded-lg bg-white shadow-lg">
-        <div className="border-b border-gray-200 px-4 py-4 sm:px-6">
-          <div className="flex flex-col items-start justify-between gap-4 sm:flex-row sm:items-center">
-            <div className="flex items-center space-x-4">
+    <div className="mx-auto max-w-7xl px-3 py-4 sm:px-6 lg:px-8">
+      <section className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+        <div
+          className="relative isolate px-4 py-5 text-white sm:px-6 sm:py-7"
+          style={{
+            background: `linear-gradient(135deg, ${teamColor}, #0f172a 72%)`,
+          }}
+        >
+          <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top_right,rgba(255,255,255,0.22),transparent_34%)]" />
+          <div className="flex flex-col gap-5 lg:flex-row lg:items-center lg:justify-between">
+            <div className="flex items-start gap-4">
               <button
                 onClick={() => navigate('/teams')}
-                className="flex items-center text-gray-600 transition-colors hover:text-gray-800"
+                className="mt-1 inline-flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-white/15 text-xl backdrop-blur transition hover:bg-white/25 focus:outline-none focus:ring-2 focus:ring-white/70"
+                aria-label="Back to teams"
               >
-                <span className="mr-2 text-xl">←</span>
-                <span className="text-sm font-medium">Back to Teams</span>
+                ←
               </button>
-            </div>
 
-            <div className="flex items-center space-x-3">
-              <button
-                onClick={() => window.location.reload()}
-                disabled={loading}
-                className="rounded-md bg-gray-100 px-3 py-2 text-sm text-gray-700 transition-colors hover:bg-gray-200 disabled:opacity-50"
-              >
-                {loading ? '⟳' : '🔄'} Refresh
-              </button>
-            </div>
-          </div>
-        </div>
-
-        {/* Team Info */}
-        {team && (
-          <div className="px-4 py-6 sm:px-6">
-            <div className="flex flex-col items-start space-y-4 sm:flex-row sm:items-center sm:space-x-6 sm:space-y-0">
-              <div
-                className="flex h-20 w-20 flex-shrink-0 items-center justify-center rounded-full text-2xl font-bold text-white"
-                style={{ backgroundColor: team.homePrimaryColor }}
-              >
-                {team.name.charAt(0).toUpperCase()}
-              </div>
-              <div className="flex-grow">
-                <h1 className="mb-2 text-2xl font-bold text-gray-900 sm:text-3xl">
-                  {team.name}
-                </h1>
-                <div className="flex flex-wrap gap-4 text-sm text-gray-600">
-                  <div className="flex items-center space-x-2">
-                    <span className="font-medium">Created:</span>
-                    <span>
-                      {team.createdAt
-                        ? new Date(team.createdAt).toLocaleDateString()
-                        : 'N/A'}
-                    </span>
+              <div className="min-w-0">
+                <div className="mb-2 flex flex-wrap items-center gap-2 text-xs font-medium uppercase tracking-wide text-white/75">
+                  <span>Teams</span>
+                  <span aria-hidden="true">/</span>
+                  <span>{currentTab?.label ?? 'Team'}</span>
+                </div>
+                <div className="flex flex-wrap items-center gap-3">
+                  <div
+                    className="flex h-14 w-14 flex-shrink-0 items-center justify-center rounded-2xl bg-white/95 text-2xl font-black shadow-sm"
+                    style={{ color: teamColor }}
+                  >
+                    {team?.name?.charAt(0).toUpperCase() ?? 'T'}
                   </div>
-                  <div className="flex items-center space-x-2">
-                    <span className="font-medium">Primary Color:</span>
-                    <div
-                      className="h-4 w-4 rounded border border-gray-300"
-                      style={{ backgroundColor: team.homePrimaryColor }}
-                    />
-                    <span>{team.homePrimaryColor}</span>
-                  </div>
-                  {team.homeSecondaryColor && (
-                    <div className="flex items-center space-x-2">
-                      <span className="font-medium">Secondary Color:</span>
-                      <div
-                        className="h-4 w-4 rounded border border-gray-300"
-                        style={{ backgroundColor: team.homeSecondaryColor }}
-                      />
-                      <span>{team.homeSecondaryColor}</span>
+                  <div className="min-w-0">
+                    <h1 className="truncate text-2xl font-black tracking-tight sm:text-4xl">
+                      {team?.name ?? (loading ? 'Loading team…' : 'Team')}
+                    </h1>
+                    <div className="mt-2 flex flex-wrap items-center gap-2 text-sm text-white/80">
+                      {team?.shortName && (
+                        <span className="rounded-full bg-white/15 px-2.5 py-1 font-semibold text-white">
+                          {team.shortName}
+                        </span>
+                      )}
+                      <span>
+                        {team?.isManaged ? 'Managed team' : 'Unmanaged team'}
+                      </span>
+                      {team?.createdAt && (
+                        <span>
+                          Created{' '}
+                          {new Date(team.createdAt).toLocaleDateString()}
+                        </span>
+                      )}
                     </div>
-                  )}
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
-        )}
-      </div>
 
-      {/* Tab Navigation */}
-      <div className="mb-6 rounded-lg bg-white shadow-lg">
-        <div className="border-b border-gray-200">
-          <nav className="flex space-x-0 overflow-x-auto">
-            {tabs.map((tab) => (
+            <button
+              onClick={() => refetch()}
+              disabled={loading}
+              className="inline-flex min-h-[44px] items-center justify-center rounded-xl bg-white px-4 py-2 text-sm font-semibold text-slate-800 shadow-sm transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              <span className={loading ? 'mr-2 animate-spin' : 'mr-2'}>⟳</span>
+              Refresh
+            </button>
+          </div>
+        </div>
+
+        <nav
+          className="flex gap-2 overflow-x-auto border-t border-slate-200 bg-slate-50/80 px-3 py-3 sm:px-5"
+          aria-label="Team navigation"
+        >
+          {tabs.map((tab) => {
+            const isActive = currentTab?.id === tab.id;
+            return (
               <Link
                 key={tab.id}
                 to={tab.path}
-                className={`
-                  flex items-center space-x-2 whitespace-nowrap border-b-2 px-4 py-4 text-sm
-                  font-medium transition-colors sm:px-6
-                  ${
-                    currentTab?.id === tab.id
-                      ? 'border-blue-500 bg-blue-50 text-blue-600'
-                      : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700'
-                  }
-                `}
+                className={`inline-flex min-h-[44px] items-center gap-2 whitespace-nowrap rounded-xl px-4 py-2 text-sm font-semibold transition focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+                  isActive
+                    ? 'bg-white text-blue-700 shadow-sm ring-1 ring-slate-200'
+                    : 'text-slate-600 hover:bg-white hover:text-slate-900'
+                }`}
+                aria-current={isActive ? 'page' : undefined}
               >
-                <span>{tab.icon}</span>
+                <span aria-hidden="true">{tab.icon}</span>
                 <span>{tab.label}</span>
               </Link>
-            ))}
-          </nav>
-        </div>
-      </div>
+            );
+          })}
+        </nav>
+      </section>
 
-      {/* Page Content */}
-      <Outlet />
+      <main className="mt-6">
+        <Outlet />
+      </main>
     </div>
   );
 };

--- a/apps/soccer-stats/ui/src/app/components/presentation/team-games.presentation.tsx
+++ b/apps/soccer-stats/ui/src/app/components/presentation/team-games.presentation.tsx
@@ -67,6 +67,16 @@ interface TeamGamesPresentationProps {
   onViewGame: (gameId: string) => void;
 }
 
+function formatGameDate(value?: string | null) {
+  if (!value) return 'Date not scheduled';
+  return new Date(value).toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
 export const TeamGamesPresentation = ({
   teamId,
   games,
@@ -85,8 +95,13 @@ export const TeamGamesPresentation = ({
 }: TeamGamesPresentationProps) => {
   if (loading) {
     return (
-      <div className="flex items-center justify-center py-12">
-        <div className="text-lg text-gray-600">Loading games...</div>
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {[0, 1, 2].map((item) => (
+          <div
+            key={item}
+            className="h-44 animate-pulse rounded-2xl bg-slate-200/80"
+          />
+        ))}
       </div>
     );
   }
@@ -105,11 +120,11 @@ export const TeamGamesPresentation = ({
       case 'PAUSED':
         return { text: 'Paused', color: 'bg-yellow-100 text-yellow-800' };
       case 'FINISHED':
-        return { text: 'Finished', color: 'bg-gray-100 text-gray-800' };
+        return { text: 'Finished', color: 'bg-slate-100 text-slate-800' };
       case 'CANCELLED':
         return { text: 'Cancelled', color: 'bg-red-100 text-red-800' };
       default:
-        return { text: status, color: 'bg-gray-100 text-gray-800' };
+        return { text: status, color: 'bg-slate-100 text-slate-800' };
     }
   };
 
@@ -121,30 +136,71 @@ export const TeamGamesPresentation = ({
     return game.currentTeamType === 'home';
   };
 
+  const scheduledGames = games.filter(
+    (game) => game.status === 'NOT_STARTED',
+  ).length;
+  const completedGames = games.filter(
+    (game) => game.status === 'FINISHED',
+  ).length;
+
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <h3 className="text-lg font-semibold text-gray-900">Games</h3>
-        <button
-          onClick={onCreateGame}
-          className="flex items-center space-x-2 rounded-md bg-blue-600 px-4 py-2 text-white transition-colors hover:bg-blue-700"
-        >
-          <span>⚽</span>
-          <span>Create New Game</span>
-        </button>
-      </div>
+      <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h2 className="text-2xl font-black text-slate-950">Games</h2>
+            <p className="mt-1 text-sm text-slate-500">
+              Schedule matches, then jump straight into tracking when it is
+              time.
+            </p>
+          </div>
+          <button
+            onClick={onCreateGame}
+            className="inline-flex min-h-[44px] items-center justify-center gap-2 rounded-xl bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+          >
+            <span aria-hidden="true">⚽</span>
+            <span>Create Game</span>
+          </button>
+        </div>
 
-      {/* Create Game Form Modal */}
+        <div className="mt-5 grid gap-3 sm:grid-cols-3">
+          <div className="rounded-xl bg-slate-50 p-4">
+            <div className="text-2xl font-black text-slate-950">
+              {games.length}
+            </div>
+            <div className="text-sm text-slate-500">total games</div>
+          </div>
+          <div className="rounded-xl bg-blue-50 p-4">
+            <div className="text-2xl font-black text-blue-900">
+              {scheduledGames}
+            </div>
+            <div className="text-sm text-blue-700">scheduled</div>
+          </div>
+          <div className="rounded-xl bg-emerald-50 p-4">
+            <div className="text-2xl font-black text-emerald-900">
+              {completedGames}
+            </div>
+            <div className="text-sm text-emerald-700">completed</div>
+          </div>
+        </div>
+      </section>
+
       {showCreateForm && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
-          <div className="mx-4 w-full max-w-md rounded-lg bg-white p-6">
-            <h3 className="mb-4 text-lg font-semibold">Create New Game</h3>
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/60 p-4 backdrop-blur-sm">
+          <div className="w-full max-w-lg overflow-hidden rounded-2xl bg-white shadow-2xl">
+            <div className="border-b border-slate-200 px-6 py-5">
+              <h3 className="text-xl font-black text-slate-950">
+                Create New Game
+              </h3>
+              <p className="mt-1 text-sm text-slate-500">
+                Pick the opponent, venue, and format. You can fill in deeper
+                details later.
+              </p>
+            </div>
 
-            <div className="space-y-4">
-              {/* Opponent Selection */}
+            <div className="space-y-4 px-6 py-5">
               <div>
-                <label className="mb-2 block text-sm font-medium text-gray-700">
+                <label className="mb-2 block text-sm font-semibold text-slate-700">
                   Opponent Team
                 </label>
                 <select
@@ -152,7 +208,7 @@ export const TeamGamesPresentation = ({
                   onChange={(e) =>
                     onFormChange('opponentTeamId', e.target.value)
                   }
-                  className="w-full rounded-md border border-gray-300 p-3 focus:border-blue-500 focus:ring-2 focus:ring-blue-500"
+                  className="min-h-[44px] w-full rounded-xl border border-slate-300 px-3 py-2 focus:border-blue-500 focus:ring-2 focus:ring-blue-500"
                   required
                 >
                   <option value="">Select opponent...</option>
@@ -164,91 +220,94 @@ export const TeamGamesPresentation = ({
                 </select>
               </div>
 
-              {/* Home/Away Selection */}
-              <div>
-                <label className="mb-2 block text-sm font-medium text-gray-700">
+              <fieldset>
+                <legend className="mb-2 block text-sm font-semibold text-slate-700">
                   Venue
-                </label>
-                <div className="flex space-x-4">
-                  <label className="flex items-center">
-                    <input
-                      type="radio"
-                      name="venue"
-                      checked={gameForm.isHome}
-                      onChange={() => onFormChange('isHome', true)}
-                      className="mr-2"
-                    />
-                    Home
-                  </label>
-                  <label className="flex items-center">
-                    <input
-                      type="radio"
-                      name="venue"
-                      checked={!gameForm.isHome}
-                      onChange={() => onFormChange('isHome', false)}
-                      className="mr-2"
-                    />
-                    Away
-                  </label>
-                </div>
-              </div>
-
-              {/* Game Format */}
-              <div>
-                <label className="mb-2 block text-sm font-medium text-gray-700">
-                  Game Format
-                </label>
-                <select
-                  value={gameForm.gameFormatId}
-                  onChange={(e) => onFormChange('gameFormatId', e.target.value)}
-                  className="w-full rounded-md border border-gray-300 p-3 focus:border-blue-500 focus:ring-2 focus:ring-blue-500"
-                >
-                  <option value="">Select game format</option>
-                  {formatOptions.map((option) => (
-                    <option key={option.value} value={option.value}>
+                </legend>
+                <div className="grid grid-cols-2 gap-3">
+                  {[
+                    { label: 'Home', value: true, icon: '🏠' },
+                    { label: 'Away', value: false, icon: '✈️' },
+                  ].map((option) => (
+                    <button
+                      key={option.label}
+                      type="button"
+                      onClick={() => onFormChange('isHome', option.value)}
+                      className={`min-h-[44px] rounded-xl border px-4 py-3 text-sm font-semibold transition ${
+                        gameForm.isHome === option.value
+                          ? 'border-blue-500 bg-blue-50 text-blue-800 ring-2 ring-blue-100'
+                          : 'border-slate-200 text-slate-600 hover:bg-slate-50'
+                      }`}
+                    >
+                      <span className="mr-2" aria-hidden="true">
+                        {option.icon}
+                      </span>
                       {option.label}
-                    </option>
+                    </button>
                   ))}
-                </select>
-              </div>
+                </div>
+              </fieldset>
 
-              {/* Duration */}
-              <div>
-                <label className="mb-2 block text-sm font-medium text-gray-700">
-                  Duration (minutes)
-                </label>
-                <input
-                  type="number"
-                  value={gameForm.duration}
-                  onChange={(e) =>
-                    onFormChange('duration', parseInt(e.target.value) || 90)
-                  }
-                  min="1"
-                  max="120"
-                  className="w-full rounded-md border border-gray-300 p-3 focus:border-blue-500 focus:ring-2 focus:ring-blue-500"
-                />
+              <div className="grid gap-4 sm:grid-cols-[1fr_140px]">
+                <div>
+                  <label className="mb-2 block text-sm font-semibold text-slate-700">
+                    Game Format
+                  </label>
+                  <select
+                    value={gameForm.gameFormatId}
+                    onChange={(e) =>
+                      onFormChange('gameFormatId', e.target.value)
+                    }
+                    className="min-h-[44px] w-full rounded-xl border border-slate-300 px-3 py-2 focus:border-blue-500 focus:ring-2 focus:ring-blue-500"
+                  >
+                    <option value="">Select format</option>
+                    {formatOptions.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                <div>
+                  <label className="mb-2 block text-sm font-semibold text-slate-700">
+                    Duration
+                  </label>
+                  <input
+                    type="number"
+                    value={gameForm.duration}
+                    onChange={(e) =>
+                      onFormChange('duration', parseInt(e.target.value) || 90)
+                    }
+                    min="1"
+                    max="120"
+                    className="min-h-[44px] w-full rounded-xl border border-slate-300 px-3 py-2 focus:border-blue-500 focus:ring-2 focus:ring-blue-500"
+                  />
+                </div>
               </div>
             </div>
 
-            {/* Error Display */}
             {error && (
-              <div className="mt-4 rounded-md bg-red-50 p-3 text-sm text-red-700">
+              <div className="mx-6 rounded-xl border border-red-200 bg-red-50 p-3 text-sm text-red-700">
                 {error}
               </div>
             )}
 
-            {/* Form Actions */}
-            <div className="mt-6 flex space-x-3">
+            <div className="flex flex-col-reverse gap-3 border-t border-slate-200 px-6 py-5 sm:flex-row sm:justify-end">
               <button
                 onClick={onCancelCreate}
-                className="flex-1 rounded-md bg-gray-200 px-4 py-2 text-gray-700 transition-colors hover:bg-gray-300"
+                className="min-h-[44px] rounded-xl border border-slate-300 px-4 py-2 font-semibold text-slate-700 transition hover:bg-slate-50"
               >
                 Cancel
               </button>
               <button
                 onClick={onSubmitGame}
-                disabled={!gameForm.opponentTeamId || createLoading}
-                className="flex-1 rounded-md bg-blue-600 px-4 py-2 text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+                disabled={
+                  !gameForm.opponentTeamId ||
+                  !gameForm.gameFormatId ||
+                  createLoading
+                }
+                className="min-h-[44px] rounded-xl bg-blue-600 px-4 py-2 font-semibold text-white shadow-sm transition hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
               >
                 {createLoading ? 'Creating...' : 'Create Game'}
               </button>
@@ -257,85 +316,84 @@ export const TeamGamesPresentation = ({
         </div>
       )}
 
-      {/* Games List */}
       {games.length === 0 ? (
-        <div className="py-12 text-center">
-          <div className="mb-4 text-gray-500">
-            <span className="text-4xl">⚽</span>
+        <div className="rounded-2xl border border-dashed border-slate-300 bg-white p-10 text-center shadow-sm">
+          <div className="text-5xl" aria-hidden="true">
+            ⚽
           </div>
-          <h3 className="mb-2 text-lg font-semibold text-gray-900">
-            No Games Yet
+          <h3 className="mt-4 text-xl font-black text-slate-950">
+            No games yet
           </h3>
-          <p className="mb-6 text-gray-600">
-            Create your first game to start tracking stats and managing lineups.
+          <p className="mx-auto mt-2 max-w-md text-slate-500">
+            Create the first game to unlock lineup tracking, stats, and match
+            history.
           </p>
+          <button
+            onClick={onCreateGame}
+            className="mt-6 inline-flex min-h-[44px] items-center rounded-xl bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-700"
+          >
+            Create first game
+          </button>
         </div>
       ) : (
-        <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
           {games.map((game) => {
             const opponent = getOpponentTeam(game);
             const isHome = isHomeTeam(game);
             const statusInfo = getGameStatus(game.status);
 
             return (
-              <div
+              <button
                 key={game.id}
-                className="cursor-pointer rounded-lg border border-gray-200 bg-white p-4 transition-shadow hover:shadow-md"
+                type="button"
+                className="group rounded-2xl border border-slate-200 bg-white p-5 text-left shadow-sm transition hover:-translate-y-0.5 hover:border-blue-300 hover:shadow-md focus:outline-none focus:ring-2 focus:ring-blue-500"
                 onClick={() => onViewGame(game.id)}
               >
-                {/* Game Header */}
-                <div className="mb-3 flex items-center justify-between">
+                <div className="mb-4 flex items-center justify-between gap-3">
                   <span
-                    className={`rounded-full px-2 py-1 text-xs font-medium ${statusInfo.color}`}
+                    className={`rounded-full px-2.5 py-1 text-xs font-bold ${statusInfo.color}`}
                   >
                     {statusInfo.text}
                   </span>
-                  <span className="text-sm text-gray-500">
+                  <span className="rounded-full bg-slate-100 px-2.5 py-1 text-xs font-semibold text-slate-600">
                     {game.format?.name || 'Unknown Format'}
                   </span>
                 </div>
 
-                {/* Teams */}
-                <div className="mb-3 space-y-2">
-                  <div className="flex items-center justify-between">
-                    <div className="flex items-center space-x-2">
-                      <span className="text-sm font-medium">
-                        {isHome ? '🏠' : '✈️'}
-                      </span>
-                      <span className="text-sm">
-                        {isHome ? 'vs' : 'at'} {opponent?.name || 'Unknown'}
-                      </span>
+                <div className="flex items-center gap-3">
+                  <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-slate-100 text-2xl">
+                    {isHome ? '🏠' : '✈️'}
+                  </div>
+                  <div className="min-w-0">
+                    <h3 className="truncate text-lg font-black text-slate-950">
+                      {isHome ? 'vs' : 'at'}{' '}
+                      {opponent?.name || 'Unknown opponent'}
+                    </h3>
+                    <p className="text-sm text-slate-500">
+                      {formatGameDate(game.scheduledStart)}
+                    </p>
+                  </div>
+                </div>
+
+                <div className="mt-5 grid grid-cols-2 gap-3 text-sm">
+                  <div className="rounded-xl bg-slate-50 p-3">
+                    <div className="text-slate-500">Score</div>
+                    <div className="mt-1 font-black text-slate-950">
+                      {game.currentTeamScore ?? '—'}
+                    </div>
+                  </div>
+                  <div className="rounded-xl bg-slate-50 p-3">
+                    <div className="text-slate-500">Created</div>
+                    <div className="mt-1 font-semibold text-slate-950">
+                      {new Date(game.createdAt).toLocaleDateString()}
                     </div>
                   </div>
                 </div>
 
-                {/* Game Info */}
-                <div className="space-y-1 text-xs text-gray-500">
-                  {game.scheduledStart && (
-                    <div>
-                      Scheduled:{' '}
-                      {new Date(game.scheduledStart).toLocaleString()}
-                    </div>
-                  )}
-                  <div>
-                    Created: {new Date(game.createdAt).toLocaleDateString()}
-                  </div>
+                <div className="mt-4 border-t border-slate-100 pt-4 text-sm font-semibold text-blue-700 group-hover:text-blue-900">
+                  {game.status === 'NOT_STARTED' ? 'Start Game' : 'View Game'} →
                 </div>
-
-                {/* Action Button */}
-                <div className="mt-3 border-t border-gray-100 pt-3">
-                  <button
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onViewGame(game.id);
-                    }}
-                    className="w-full text-sm font-medium text-blue-600 hover:text-blue-800"
-                  >
-                    {game.status === 'NOT_STARTED' ? 'Start Game' : 'View Game'}{' '}
-                    →
-                  </button>
-                </div>
-              </div>
+              </button>
             );
           })}
         </div>

--- a/apps/soccer-stats/ui/src/app/components/presentation/team-settings.presentation.tsx
+++ b/apps/soccer-stats/ui/src/app/components/presentation/team-settings.presentation.tsx
@@ -1,5 +1,4 @@
 import { useState, useCallback, useEffect } from 'react';
-import { Link } from 'react-router';
 
 import {
   createTeamFormValues,
@@ -118,24 +117,24 @@ export const TeamSettingsPresentation = ({
   ]);
 
   return (
-    <div className="rounded-lg bg-white shadow-lg">
+    <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
       {/* Header */}
-      <div className="border-b border-gray-200 px-6 py-4">
-        <div className="flex items-center justify-between">
+      <div className="border-b border-slate-200 bg-slate-50 px-6 py-5">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <div>
-            <h2 className="text-xl font-semibold text-gray-900">
+            <h2 className="text-2xl font-black text-slate-950">
               Team Settings
             </h2>
-            <p className="mt-1 text-gray-600">
-              Configure your team's basic information, formation, and roster
+            <p className="mt-1 max-w-2xl text-sm text-slate-600">
+              Configure basic details, default game format, formations, and stat
+              tracking in one place.
             </p>
           </div>
-          <Link
-            to="/teams"
-            className="inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm transition-colors hover:bg-gray-50"
-          >
-            ← Back to Teams
-          </Link>
+          {saveSuccess && (
+            <div className="rounded-full bg-emerald-100 px-3 py-1 text-sm font-semibold text-emerald-800">
+              Saved
+            </div>
+          )}
         </div>
       </div>
 

--- a/apps/soccer-stats/ui/src/app/components/smart/team-settings.smart.tsx
+++ b/apps/soccer-stats/ui/src/app/components/smart/team-settings.smart.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useEffect } from 'react';
 import { useQuery, useMutation } from '@apollo/client/react';
-import { useParams, useNavigate } from 'react-router';
+import { useParams } from 'react-router';
 
 import {
   GameFormat,
@@ -28,7 +28,6 @@ import { useTeamConfigurationManager } from './team-configuration-manager.smart'
 
 export const TeamSettingsSmart = () => {
   const { teamId } = useParams<{ teamId: string }>();
-  const navigate = useNavigate();
   const [saveSuccess, setSaveSuccess] = useState(false);
   const [statsFeatures, setStatsFeatures] = useState<UIStatsFeatures>(
     UI_DEFAULT_STATS_FEATURES,
@@ -37,7 +36,6 @@ export const TeamSettingsSmart = () => {
   // Team configuration manager
   const {
     gameFormats,
-    formations,
     availableFormations,
     selectedGameFormat,
     selectedFormation,
@@ -47,7 +45,6 @@ export const TeamSettingsSmart = () => {
     updatePosition,
     addPosition,
     removePosition,
-    resetConfiguration,
   } = useTeamConfigurationManager();
 
   // Fetch existing team data
@@ -207,13 +204,11 @@ export const TeamSettingsSmart = () => {
   // Show loading state for fetching
   if (fetchLoading) {
     return (
-      <div className="mx-auto max-w-6xl p-6">
-        <div className="rounded-lg bg-white p-6 shadow-lg">
-          <div className="animate-pulse">
-            <div className="mb-4 h-8 rounded bg-gray-200"></div>
-            <div className="mb-2 h-4 rounded bg-gray-200"></div>
-            <div className="h-4 w-2/3 rounded bg-gray-200"></div>
-          </div>
+      <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+        <div className="animate-pulse space-y-4">
+          <div className="h-8 rounded bg-slate-200"></div>
+          <div className="h-4 rounded bg-slate-200"></div>
+          <div className="h-4 w-2/3 rounded bg-slate-200"></div>
         </div>
       </div>
     );
@@ -222,12 +217,10 @@ export const TeamSettingsSmart = () => {
   // Show error state
   if (fetchError || !teamData?.team) {
     return (
-      <div className="mx-auto max-w-6xl p-6">
-        <div className="rounded-md border border-red-200 bg-red-50 p-4">
-          <p className="text-red-800">
-            {fetchError?.message || 'Team not found'}
-          </p>
-        </div>
+      <div className="rounded-2xl border border-red-200 bg-red-50 p-5">
+        <p className="font-medium text-red-800">
+          {fetchError?.message || 'Team not found'}
+        </p>
       </div>
     );
   }
@@ -251,26 +244,24 @@ export const TeamSettingsSmart = () => {
   const errorMessage = updateError?.message || configError?.message;
 
   return (
-    <div className="mx-auto max-w-6xl p-6">
-      <TeamSettingsPresentation
-        team={team as any} // TODO: Fix type when migrating to new architecture
-        selectedGameFormat={selectedGameFormat}
-        selectedFormation={selectedFormation}
-        statsFeatures={statsFeatures}
-        gameFormats={gameFormats}
-        formations={availableFormations}
-        positions={positions}
-        onSaveSettings={handleSaveSettings}
-        onGameFormatSelect={selectGameFormat}
-        onFormationSelect={selectFormation}
-        onStatsFeaturesChange={setStatsFeatures}
-        onPositionUpdate={updatePosition}
-        onAddPosition={handleAddPosition}
-        onRemovePosition={removePosition}
-        loading={isLoading}
-        error={errorMessage}
-        saveSuccess={saveSuccess}
-      />
-    </div>
+    <TeamSettingsPresentation
+      team={team as any} // TODO: Fix type when migrating to new architecture
+      selectedGameFormat={selectedGameFormat}
+      selectedFormation={selectedFormation}
+      statsFeatures={statsFeatures}
+      gameFormats={gameFormats}
+      formations={availableFormations}
+      positions={positions}
+      onSaveSettings={handleSaveSettings}
+      onGameFormatSelect={selectGameFormat}
+      onFormationSelect={selectFormation}
+      onStatsFeaturesChange={setStatsFeatures}
+      onPositionUpdate={updatePosition}
+      onAddPosition={handleAddPosition}
+      onRemovePosition={removePosition}
+      loading={isLoading}
+      error={errorMessage}
+      saveSuccess={saveSuccess}
+    />
   );
 };

--- a/apps/soccer-stats/ui/src/app/pages/team-overview.page.tsx
+++ b/apps/soccer-stats/ui/src/app/pages/team-overview.page.tsx
@@ -1,9 +1,43 @@
-import { useParams } from 'react-router';
+import { Link, useParams } from 'react-router';
 import { useQuery } from '@apollo/client/react';
 
 import { GetTeamByIdQuery } from '@garage/soccer-stats/graphql-codegen';
 
 import { GET_TEAM_BY_ID } from '../services/teams-graphql.service';
+
+function formatDate(value?: string | null) {
+  if (!value) return 'Not set';
+  return new Date(value).toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+function statCard(
+  label: string,
+  value: string | number,
+  helper: string,
+  icon: string,
+) {
+  return (
+    <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="text-sm font-medium text-slate-500">{label}</p>
+          <p className="mt-2 text-3xl font-black text-slate-950">{value}</p>
+        </div>
+        <span
+          className="rounded-2xl bg-blue-50 p-3 text-2xl"
+          aria-hidden="true"
+        >
+          {icon}
+        </span>
+      </div>
+      <p className="mt-3 text-sm text-slate-500">{helper}</p>
+    </div>
+  );
+}
 
 /**
  * Page component for team overview information
@@ -23,28 +57,33 @@ export const TeamOverviewPage = () => {
 
   if (!teamId) {
     return (
-      <div className="p-4">
-        <div className="text-red-600">Error: No team ID provided</div>
+      <div className="rounded-xl border border-red-200 bg-red-50 p-4 text-red-700">
+        Error: No team ID provided
       </div>
     );
   }
 
   if (loading && !data) {
     return (
-      <div className="flex h-64 items-center justify-center">
-        <div className="text-lg">Loading team details...</div>
+      <div className="grid gap-4 md:grid-cols-3">
+        {[0, 1, 2].map((item) => (
+          <div
+            key={item}
+            className="h-36 animate-pulse rounded-2xl bg-slate-200/80"
+          />
+        ))}
       </div>
     );
   }
 
   if (error && !data) {
     return (
-      <div className="p-4 text-center text-red-600">
+      <div className="rounded-2xl border border-red-200 bg-red-50 p-6 text-center text-red-700">
         <div className="text-lg font-semibold">Error loading team</div>
         <div className="mt-2 text-sm">{error.message}</div>
         <button
           onClick={() => refetch()}
-          className="mt-4 rounded bg-blue-600 px-4 py-2 text-white hover:bg-blue-700"
+          className="mt-4 min-h-[44px] rounded-xl bg-red-600 px-4 py-2 font-semibold text-white shadow-sm transition hover:bg-red-700"
         >
           Try Again
         </button>
@@ -58,118 +97,235 @@ export const TeamOverviewPage = () => {
 
   if (!team) {
     return (
-      <div className="p-4 text-center">
-        <div className="text-lg">Team not found</div>
+      <div className="rounded-2xl border border-amber-200 bg-amber-50 p-6 text-center text-amber-800">
+        <div className="text-lg font-semibold">Team not found</div>
       </div>
     );
   }
 
+  const roster = team.roster ?? [];
+  const activePlayers = roster.filter((player) => player.teamMember.isActive);
+  const games = team.games ?? [];
+  const teamColor = team.homePrimaryColor || '#2563eb';
+  const upcomingGames = games
+    .filter((game) => game.game?.scheduledStart)
+    .slice()
+    .sort(
+      (a, b) =>
+        new Date(a.game?.scheduledStart ?? 0).getTime() -
+        new Date(b.game?.scheduledStart ?? 0).getTime(),
+    )
+    .slice(0, 3);
+
+  const ownerName = team.owner
+    ? `${team.owner.user.firstName ?? ''} ${team.owner.user.lastName ?? ''}`.trim() ||
+      team.owner.user.email
+    : 'Not assigned';
+
   return (
-    <div className="rounded-lg bg-white p-4 shadow-lg sm:p-6">
-      <div className="space-y-6">
-        <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
-          <div className="rounded-lg bg-gray-50 p-4">
-            <h3 className="mb-2 text-lg font-semibold text-gray-900">
-              Team Information
-            </h3>
-            <div className="space-y-2 text-sm">
-              <div className="flex justify-between">
-                <span className="text-gray-600">Name:</span>
-                <span className="font-medium">{team.name}</span>
-              </div>
-              <div className="flex justify-between">
-                <span className="text-gray-600">Owner:</span>
-                <span className="font-medium">
-                  {team.owner
-                    ? `${team.owner.user.firstName} ${team.owner.user.lastName}`
-                    : 'Not assigned'}
-                </span>
-              </div>
-              <div className="flex justify-between">
-                <span className="text-gray-600">Created:</span>
-                <span className="font-medium">
-                  {team.createdAt
-                    ? new Date(team.createdAt).toLocaleDateString()
-                    : 'N/A'}
-                </span>
-              </div>
-              <div className="flex justify-between">
-                <span className="text-gray-600">ID:</span>
-                <span className="font-mono text-xs">{team.id}</span>
-              </div>
-            </div>
-          </div>
-
-          <div className="rounded-lg bg-gray-50 p-4">
-            <h3 className="mb-2 text-lg font-semibold text-gray-900">
-              Quick Stats
-            </h3>
-            <div className="space-y-2 text-sm">
-              <div className="flex justify-between">
-                <span className="text-gray-600">Total Players:</span>
-                <span className="font-medium">
-                  {
-                    0 /* TODO: Calculate player count when migrating to new architecture */
-                  }
-                </span>
-              </div>
-              <div className="flex justify-between">
-                <span className="text-gray-600">Games Played:</span>
-                <span className="font-medium">0</span>
-              </div>
-              <div className="flex justify-between">
-                <span className="text-gray-600">Wins:</span>
-                <span className="font-medium">0</span>
-              </div>
-            </div>
-          </div>
-
-          <div className="rounded-lg bg-gray-50 p-4">
-            <h3 className="mb-2 text-lg font-semibold text-gray-900">
-              Team Colors
-            </h3>
-            <div className="space-y-3">
-              <div className="flex items-center space-x-3">
-                <div
-                  className="h-8 w-8 rounded border border-gray-300"
-                  style={{
-                    backgroundColor: team.homePrimaryColor ?? undefined,
-                  }}
-                />
-                <div>
-                  <div className="text-sm font-medium">Primary</div>
-                  <div className="text-xs text-gray-600">
-                    {team.homePrimaryColor}
-                  </div>
-                </div>
-              </div>
-              {team.homeSecondaryColor && (
-                <div className="flex items-center space-x-3">
-                  <div
-                    className="h-8 w-8 rounded border border-gray-300"
-                    style={{
-                      backgroundColor: team.homeSecondaryColor ?? undefined,
-                    }}
-                  />
-                  <div>
-                    <div className="text-sm font-medium">Secondary</div>
-                    <div className="text-xs text-gray-600">
-                      {team.homeSecondaryColor}
-                    </div>
-                  </div>
-                </div>
-              )}
-            </div>
-          </div>
-        </div>
-
-        <div className="mt-8 text-center text-gray-500">
-          <p>
-            Use the navigation to manage players, view games, and analyze
-            statistics.
-          </p>
-        </div>
+    <div className="space-y-6">
+      <div className="grid gap-4 md:grid-cols-3">
+        {statCard(
+          'Active Players',
+          activePlayers.length,
+          `${roster.length} total roster spots`,
+          '👥',
+        )}
+        {statCard(
+          'Games Tracked',
+          games.length,
+          'Scheduled and historical games',
+          '⚽',
+        )}
+        {statCard(
+          'Default Format',
+          team.teamConfiguration?.defaultGameFormat?.name ?? 'Unset',
+          team.teamConfiguration?.defaultFormation
+            ? `Formation ${team.teamConfiguration.defaultFormation}`
+            : 'Set a format in Settings',
+          '📋',
+        )}
       </div>
+
+      <div className="grid gap-6 lg:grid-cols-[1.4fr_0.9fr]">
+        <section className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+          <div className="border-b border-slate-200 bg-slate-50 px-5 py-4">
+            <h2 className="text-lg font-bold text-slate-950">Team Snapshot</h2>
+            <p className="mt-1 text-sm text-slate-500">
+              The essentials at a glance, without making you hunt through
+              settings.
+            </p>
+          </div>
+          <div className="grid gap-0 divide-y divide-slate-100 p-5 sm:grid-cols-2 sm:divide-x sm:divide-y-0">
+            <dl className="space-y-4 pb-5 sm:pb-0 sm:pr-5">
+              <div>
+                <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  Name
+                </dt>
+                <dd className="mt-1 font-semibold text-slate-950">
+                  {team.name}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  Owner
+                </dt>
+                <dd className="mt-1 font-semibold text-slate-950">
+                  {ownerName}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  Created
+                </dt>
+                <dd className="mt-1 font-semibold text-slate-950">
+                  {formatDate(team.createdAt)}
+                </dd>
+              </div>
+            </dl>
+
+            <div className="space-y-4 pt-5 sm:pl-5 sm:pt-0">
+              <div>
+                <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  Team Colors
+                </h3>
+                <div className="mt-3 flex flex-wrap gap-3">
+                  {[
+                    ['Home primary', team.homePrimaryColor],
+                    ['Home secondary', team.homeSecondaryColor],
+                    ['Away primary', team.awayPrimaryColor],
+                    ['Away secondary', team.awaySecondaryColor],
+                  ].map(([label, color]) => (
+                    <div
+                      key={label}
+                      className="flex min-w-0 items-center gap-2 rounded-xl border border-slate-200 px-3 py-2"
+                    >
+                      <span
+                        className="h-6 w-6 flex-shrink-0 rounded-lg border border-slate-300"
+                        style={{ backgroundColor: color || '#f8fafc' }}
+                        aria-hidden="true"
+                      />
+                      <div className="min-w-0">
+                        <div className="truncate text-xs font-semibold text-slate-700">
+                          {label}
+                        </div>
+                        <div className="font-mono text-xs text-slate-500">
+                          {color || 'Unset'}
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              <div>
+                <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  Team ID
+                </h3>
+                <p className="mt-2 break-all rounded-xl bg-slate-50 p-3 font-mono text-xs text-slate-600">
+                  {team.id}
+                </p>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <aside className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+          <h2 className="text-lg font-bold text-slate-950">
+            Next best actions
+          </h2>
+          <p className="mt-1 text-sm text-slate-500">
+            Common team-management tasks, one tap away.
+          </p>
+          <div className="mt-5 grid gap-3">
+            <Link
+              to={`/teams/${teamId}/players`}
+              className="rounded-xl border border-slate-200 p-4 transition hover:border-blue-300 hover:bg-blue-50"
+            >
+              <div className="font-semibold text-slate-950">Manage roster</div>
+              <div className="mt-1 text-sm text-slate-500">
+                Add players, jersey numbers, and positions.
+              </div>
+            </Link>
+            <Link
+              to={`/teams/${teamId}/games`}
+              className="rounded-xl border border-slate-200 p-4 transition hover:border-blue-300 hover:bg-blue-50"
+            >
+              <div className="font-semibold text-slate-950">
+                Create or review games
+              </div>
+              <div className="mt-1 text-sm text-slate-500">
+                Schedule matches before tracking stats.
+              </div>
+            </Link>
+            <Link
+              to={`/teams/${teamId}/settings`}
+              className="rounded-xl border border-slate-200 p-4 transition hover:border-blue-300 hover:bg-blue-50"
+            >
+              <div className="font-semibold text-slate-950">
+                Tune team setup
+              </div>
+              <div className="mt-1 text-sm text-slate-500">
+                Update colors, format, formations, and stat options.
+              </div>
+            </Link>
+          </div>
+        </aside>
+      </div>
+
+      <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h2 className="text-lg font-bold text-slate-950">Upcoming games</h2>
+            <p className="text-sm text-slate-500">
+              The next scheduled items for this team.
+            </p>
+          </div>
+          <Link
+            to={`/teams/${teamId}/games`}
+            className="text-sm font-semibold text-blue-700 hover:text-blue-900"
+          >
+            View all games →
+          </Link>
+        </div>
+
+        {upcomingGames.length > 0 ? (
+          <div className="mt-4 grid gap-3 md:grid-cols-3">
+            {upcomingGames.map((game) => (
+              <div key={game.id} className="rounded-xl bg-slate-50 p-4">
+                <div className="text-sm font-semibold text-slate-950">
+                  {game.game?.name || 'Game'}
+                </div>
+                <div className="mt-1 text-sm text-slate-500">
+                  {formatDate(game.game?.scheduledStart)}
+                </div>
+                <div
+                  className="mt-3 h-1.5 rounded-full"
+                  style={{ backgroundColor: teamColor }}
+                />
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="mt-4 rounded-2xl border border-dashed border-slate-300 bg-slate-50 p-8 text-center">
+            <div className="text-3xl" aria-hidden="true">
+              ⚽
+            </div>
+            <h3 className="mt-3 font-semibold text-slate-950">
+              No games scheduled yet
+            </h3>
+            <p className="mt-1 text-sm text-slate-500">
+              Create a game when the schedule is ready.
+            </p>
+            <Link
+              to={`/teams/${teamId}/games`}
+              className="mt-4 inline-flex min-h-[44px] items-center rounded-xl bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-700"
+            >
+              Go to games
+            </Link>
+          </div>
+        )}
+      </section>
     </div>
   );
 };

--- a/apps/soccer-stats/ui/src/app/pages/team-players.page.tsx
+++ b/apps/soccer-stats/ui/src/app/pages/team-players.page.tsx
@@ -217,18 +217,18 @@ export const TeamPlayersPage = () => {
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="rounded-lg bg-white p-6 shadow-lg">
+      <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
         <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
           <div>
-            <h2 className="text-2xl font-bold text-gray-900">Team Roster</h2>
-            <p className="mt-1 text-gray-600">
+            <h2 className="text-2xl font-black text-slate-950">Team Roster</h2>
+            <p className="mt-1 text-sm text-slate-600">
               {activePlayers.length} active player
               {activePlayers.length !== 1 ? 's' : ''}
               {inactivePlayers.length > 0 &&
-                ` (${inactivePlayers.length} inactive)`}
+                ` · ${inactivePlayers.length} inactive`}
             </p>
           </div>
-          <div className="flex items-center gap-4">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
             {inactivePlayers.length > 0 && (
               <label className="flex cursor-pointer items-center gap-2 text-sm text-gray-600">
                 <input
@@ -242,7 +242,7 @@ export const TeamPlayersPage = () => {
             )}
             <button
               onClick={() => setShowCreateModal(true)}
-              className="inline-flex items-center rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-blue-700"
+              className="inline-flex min-h-[44px] items-center justify-center rounded-xl bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
             >
               <svg
                 className="mr-2 h-4 w-4"
@@ -265,7 +265,7 @@ export const TeamPlayersPage = () => {
 
       {/* Players Grid */}
       {teamPlayers.length === 0 ? (
-        <div className="rounded-lg border-2 border-dashed border-gray-300 bg-white p-12 text-center">
+        <div className="rounded-2xl border border-dashed border-slate-300 bg-white p-12 text-center shadow-sm">
           <svg
             className="mx-auto h-12 w-12 text-gray-400"
             fill="none"
@@ -286,7 +286,7 @@ export const TeamPlayersPage = () => {
           <div className="mt-6">
             <button
               onClick={() => setShowCreateModal(true)}
-              className="inline-flex items-center rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-blue-700"
+              className="inline-flex min-h-[44px] items-center justify-center rounded-xl bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
             >
               <svg
                 className="mr-2 h-4 w-4"


### PR DESCRIPTION
## Summary
- Rework the team layout into a branded hero/header with improved responsive tab navigation
- Redesign the team overview with dashboard cards, action cards, color swatches, and clearer empty states
- Polish games, roster, settings, and signed-out team-page UX while staying in Tailwind utilities

## Test Plan
- [x] pnpm nx lint soccer-stats-ui
- [x] pnpm nx build soccer-stats-ui --skip-nx-cache

## Notes
- Lint passes with existing warnings in the app.
- Build still reports the existing large chunk and stale Browserslist warnings.
