### PR TITLE
feat(soccer-stats): add game alerts and fix team page polish

### DIFF
--- a/apps/soccer-stats/api/src/modules/teams/teams.service.spec.ts
+++ b/apps/soccer-stats/api/src/modules/teams/teams.service.spec.ts
@@ -1,0 +1,109 @@
+import { Repository } from 'typeorm';
+
+import { Team } from '../../entities/team.entity';
+import { TeamConfiguration } from '../../entities/team-configuration.entity';
+import { GameTeam } from '../../entities/game-team.entity';
+import { GameFormat } from '../../entities/game-format.entity';
+import { TeamMembersService } from '../team-members/team-members.service';
+
+import { TeamsService } from './teams.service';
+
+describe('TeamsService', () => {
+  let service: TeamsService;
+  let teamRepository: jest.Mocked<Pick<Repository<Team>, 'findOne'>>;
+  let teamConfigurationRepository: {
+    findOne: jest.Mock;
+    create: jest.Mock;
+    save: jest.Mock;
+  };
+
+  beforeEach(() => {
+    teamRepository = {
+      findOne: jest.fn(),
+    };
+    const gameTeamRepository = {
+      find: jest.fn(),
+    } as unknown as Repository<GameTeam>;
+    teamConfigurationRepository = {
+      findOne: jest.fn(),
+      create: jest.fn((config) => config as TeamConfiguration),
+      save: jest.fn(),
+    };
+    const teamMembersService = {} as TeamMembersService;
+
+    service = new TeamsService(
+      teamRepository as unknown as Repository<Team>,
+      gameTeamRepository,
+      teamConfigurationRepository as unknown as Repository<TeamConfiguration>,
+      teamMembersService,
+    );
+  });
+
+  describe('getTeamConfiguration', () => {
+    it('loads the default game format relation for GraphQL population', async () => {
+      const defaultGameFormat = {
+        id: 'format-1',
+        name: '9v9',
+        playersPerTeam: 9,
+        durationMinutes: 70,
+      } as GameFormat;
+      const config = {
+        id: 'config-1',
+        teamId: 'team-1',
+        defaultGameFormatId: defaultGameFormat.id,
+        defaultGameFormat,
+      } as TeamConfiguration;
+      teamConfigurationRepository.findOne.mockResolvedValue(config);
+
+      await expect(service.getTeamConfiguration('team-1')).resolves.toBe(
+        config,
+      );
+
+      expect(teamConfigurationRepository.findOne).toHaveBeenCalledWith({
+        where: { teamId: 'team-1' },
+        relations: { defaultGameFormat: true },
+      });
+    });
+  });
+
+  describe('updateTeamConfiguration', () => {
+    it('returns the saved configuration with defaultGameFormat populated', async () => {
+      const existingConfig = {
+        id: 'config-1',
+        teamId: 'team-1',
+        defaultGameFormatId: null,
+      } as TeamConfiguration;
+      const reloadedConfig = {
+        ...existingConfig,
+        defaultGameFormatId: 'format-1',
+        defaultGameFormat: {
+          id: 'format-1',
+          name: '9v9',
+          playersPerTeam: 9,
+          durationMinutes: 70,
+        } as GameFormat,
+      } as TeamConfiguration;
+
+      teamRepository.findOne.mockResolvedValue({ id: 'team-1' } as Team);
+      teamConfigurationRepository.findOne
+        .mockResolvedValueOnce(existingConfig)
+        .mockResolvedValueOnce(reloadedConfig);
+      teamConfigurationRepository.save.mockResolvedValue(reloadedConfig);
+
+      await expect(
+        service.updateTeamConfiguration('team-1', {
+          defaultGameFormatId: 'format-1',
+        }),
+      ).resolves.toBe(reloadedConfig);
+
+      expect(teamConfigurationRepository.save).toHaveBeenCalledWith({
+        ...existingConfig,
+        defaultGameFormatId: 'format-1',
+      });
+      expect(teamConfigurationRepository.findOne).toHaveBeenLastCalledWith({
+        where: { teamId: 'team-1' },
+        relations: { defaultGameFormat: true },
+      });
+    });
+  });
+});

--- a/apps/soccer-stats/api/src/modules/teams/teams.service.ts
+++ b/apps/soccer-stats/api/src/modules/teams/teams.service.ts
@@ -515,6 +515,7 @@ export class TeamsService {
   ): Promise<TeamConfiguration | null> {
     return this.teamConfigurationRepository.findOne({
       where: { teamId },
+      relations: { defaultGameFormat: true },
     });
   }
 
@@ -545,6 +546,15 @@ export class TeamsService {
       });
     }
 
-    return this.teamConfigurationRepository.save(config);
+    await this.teamConfigurationRepository.save(config);
+
+    const updatedConfig = await this.getTeamConfiguration(teamId);
+    if (!updatedConfig) {
+      throw new NotFoundException(
+        `Team configuration for team "${teamId}" not found after save`,
+      );
+    }
+
+    return updatedConfig;
   }
 }

--- a/apps/soccer-stats/ui/src/app/components/layout/team-layout.tsx
+++ b/apps/soccer-stats/ui/src/app/components/layout/team-layout.tsx
@@ -26,7 +26,7 @@ export const TeamLayout = () => {
   const navigate = useNavigate();
   const location = useLocation();
 
-  const { data, loading, refetch } = useQuery<TeamResponse>(GET_TEAM_BY_ID, {
+  const { data, loading } = useQuery<TeamResponse>(GET_TEAM_BY_ID, {
     variables: { id: teamId },
     errorPolicy: 'all',
     fetchPolicy: 'cache-and-network',
@@ -92,7 +92,7 @@ export const TeamLayout = () => {
           }}
         >
           <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top_right,rgba(255,255,255,0.22),transparent_34%)]" />
-          <div className="flex flex-col gap-5 lg:flex-row lg:items-center lg:justify-between">
+          <div className="flex flex-col gap-5 lg:flex-row lg:items-center">
             <div className="flex items-start gap-4">
               <button
                 onClick={() => navigate('/teams')}
@@ -139,15 +139,6 @@ export const TeamLayout = () => {
                 </div>
               </div>
             </div>
-
-            <button
-              onClick={() => refetch()}
-              disabled={loading}
-              className="inline-flex min-h-[44px] items-center justify-center rounded-xl bg-white px-4 py-2 text-sm font-semibold text-slate-800 shadow-sm transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-60"
-            >
-              <span className={loading ? 'mr-2 animate-spin' : 'mr-2'}>⟳</span>
-              Refresh
-            </button>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- Follow-up to #279 because the original PR merged before the refresh-button cleanup landed on `main`
- Removes the shared team-page Refresh button from the team layout
- Fixes GraphQL team configuration population so `defaultGameFormat` is loaded from `defaultGameFormatId` instead of showing as unset
- Reloads the saved team configuration with its `defaultGameFormat` relation after settings updates
- Adds opt-in PWA/browser game alerts for goals and other live game events from the existing `gameEventChanged` subscription

## Test Plan
- [x] pnpm nx test soccer-stats-api --testFile=apps/soccer-stats/api/src/modules/teams/teams.service.spec.ts --skip-nx-cache
- [x] pnpm nx lint soccer-stats-api
- [x] pnpm nx build soccer-stats-api --skip-nx-cache
- [x] pnpm nx test soccer-stats-ui --testFile=apps/soccer-stats/ui/src/app/pwa/game-event-notifications.spec.ts --skip-nx-cache
- [x] pnpm nx lint soccer-stats-ui
- [x] pnpm nx build soccer-stats-ui --skip-nx-cache

## Notes
- Notifications are local/browser notifications driven by the live game subscription while the PWA/app is running. Full background push for closed apps would require Push API subscription storage, VAPID keys, and server-side web-push delivery.
- API/UI lint pass with existing warnings.
- UI build still reports existing large chunk and stale Browserslist warnings.