### PR TITLE
feat(soccer-stats): add game event notifications

### DIFF
--- a/apps/soccer-stats/ui/src/app/pages/game.page.tsx
+++ b/apps/soccer-stats/ui/src/app/pages/game.page.tsx
@@ -56,6 +56,13 @@ import { LineupPanel } from '../components/smart/lineup-panel';
 import { GameStats } from '../components/smart/game-stats.smart';
 import { GameSummaryPresentation } from '../components/presentation/game-summary.presentation';
 import { useSyncedGameTime } from '../hooks/use-synced-game-time';
+import {
+  areGameEventNotificationsEnabled,
+  enableGameEventNotifications,
+  disableGameEventNotifications,
+  getNotificationPermission,
+  notifyGameEvent,
+} from '../pwa/game-event-notifications';
 
 import { computeScore, GameHeader, StickyScoreBar } from './game';
 
@@ -147,6 +154,15 @@ export const GamePage = () => {
   const [clearEventsOnReset, setClearEventsOnReset] = useState(false);
   const [showReopenConfirm, setShowReopenConfirm] = useState(false);
   const [showManualGoalModal, setShowManualGoalModal] = useState(false);
+  const [gameEventNotificationsEnabled, setGameEventNotificationsEnabled] =
+    useState(
+      () =>
+        areGameEventNotificationsEnabled() &&
+        getNotificationPermission() === 'granted',
+    );
+  const [notificationPermission, setNotificationPermission] = useState(() =>
+    getNotificationPermission(),
+  );
 
   // Action error state - displayed as dismissible banner
   const [actionError, setActionError] = useState<string | null>(null);
@@ -639,6 +655,12 @@ export const GamePage = () => {
       playerId?: string | null;
       externalPlayerName?: string | null;
       externalPlayerNumber?: string | null;
+      player?: {
+        id: string;
+        firstName?: string | null;
+        lastName?: string | null;
+      } | null;
+      formation?: string | null;
       eventType: { id: string; name: string; category: string };
       childEvents?: Array<{
         id: string;
@@ -675,11 +697,18 @@ export const GamePage = () => {
                 period: event.period ?? null,
                 periodSecond: event.periodSecond,
                 position: event.position ?? null,
-                formation: null,
+                formation: event.formation ?? null,
                 playerId: event.playerId,
                 externalPlayerName: event.externalPlayerName,
                 externalPlayerNumber: event.externalPlayerNumber,
-                player: null, // Will be populated by server response
+                player: event.player
+                  ? {
+                      __typename: 'User',
+                      id: event.player.id,
+                      firstName: event.player.firstName,
+                      lastName: event.player.lastName,
+                    }
+                  : null,
                 eventType: {
                   __typename: 'EventType',
                   ...event.eventType,
@@ -748,11 +777,49 @@ export const GamePage = () => {
         }, 150);
       }
 
+      const eventTeam =
+        event.gameTeamId === homeTeamData?.id
+          ? homeTeamData
+          : event.gameTeamId === awayTeamData?.id
+            ? awayTeamData
+            : null;
+      if (eventTeam) {
+        const teamType = eventTeam.teamType as 'home' | 'away';
+        const notificationHomeScore =
+          event.eventType.name === 'GOAL' && teamType === 'home'
+            ? homeScore + 1
+            : homeScore;
+        const notificationAwayScore =
+          event.eventType.name === 'GOAL' && teamType === 'away'
+            ? awayScore + 1
+            : awayScore;
+
+        notifyGameEvent(event, {
+          gameName: data?.game?.name || 'Game update',
+          teamName: eventTeam.team.name,
+          opponentName:
+            teamType === 'home'
+              ? awayTeamData?.team.name
+              : homeTeamData?.team.name,
+          teamType,
+          homeScore: notificationHomeScore,
+          awayScore: notificationAwayScore,
+        });
+      }
+
       // Note: Score highlight animations are now triggered by useEffect watching
       // homeScore/awayScore changes, ensuring animation is synchronized with
       // the displayed score update (not the subscription message timing).
     },
-    [apolloClient, gameId],
+    [
+      apolloClient,
+      gameId,
+      homeTeamData,
+      awayTeamData,
+      homeScore,
+      awayScore,
+      data?.game?.name,
+    ],
   );
 
   const handleEventDeleted = useCallback(
@@ -789,6 +856,27 @@ export const GamePage = () => {
     },
     [],
   );
+
+  const handleToggleGameEventNotifications = useCallback(async () => {
+    if (gameEventNotificationsEnabled) {
+      disableGameEventNotifications();
+      setGameEventNotificationsEnabled(false);
+      setNotificationPermission(getNotificationPermission());
+      return;
+    }
+
+    const permission = await enableGameEventNotifications();
+    setNotificationPermission(permission);
+    setGameEventNotificationsEnabled(permission === 'granted');
+
+    if (permission === 'denied') {
+      setActionError(
+        'Notifications are blocked for this browser. Enable them in browser settings to receive game alerts.',
+      );
+    } else if (permission === 'unsupported') {
+      setActionError('This browser does not support game event notifications.');
+    }
+  }, [gameEventNotificationsEnabled]);
 
   // Refs for subscription callbacks - keeps subscriptions stable across re-renders.
   // Without refs, every cache update creates new callback references, which would
@@ -1591,6 +1679,8 @@ export const GamePage = () => {
         }
         isPaused={!!game.pausedAt}
         isConnected={isConnected}
+        gameEventNotificationsEnabled={gameEventNotificationsEnabled}
+        notificationPermission={notificationPermission}
         showGameMenu={showGameMenu}
         showResetConfirm={showResetConfirm}
         clearEventsOnReset={clearEventsOnReset}
@@ -1598,6 +1688,7 @@ export const GamePage = () => {
         onToggleMenu={() => setShowGameMenu(!showGameMenu)}
         onCloseMenu={() => setShowGameMenu(false)}
         onTogglePause={handleTogglePause}
+        onToggleGameEventNotifications={handleToggleGameEventNotifications}
         onStatsTrackingChange={handleStatsTrackingChange}
         onShowResetConfirm={setShowResetConfirm}
         onClearEventsChange={setClearEventsOnReset}

--- a/apps/soccer-stats/ui/src/app/pages/game/game-header.presentation.tsx
+++ b/apps/soccer-stats/ui/src/app/pages/game/game-header.presentation.tsx
@@ -18,6 +18,8 @@ export interface GameHeaderProps {
   statsFeatures: StatsFeatures;
   isPaused: boolean;
   isConnected: boolean;
+  gameEventNotificationsEnabled: boolean;
+  notificationPermission: NotificationPermission | 'unsupported';
   showGameMenu: boolean;
   showResetConfirm: boolean;
   clearEventsOnReset: boolean;
@@ -25,6 +27,7 @@ export interface GameHeaderProps {
   onToggleMenu: () => void;
   onCloseMenu: () => void;
   onTogglePause: () => void;
+  onToggleGameEventNotifications: () => void;
   onStatsTrackingChange: (features: StatsFeatures) => void;
   onShowResetConfirm: (show: boolean) => void;
   onClearEventsChange: (clear: boolean) => void;
@@ -57,6 +60,8 @@ export function GameHeader({
   statsFeatures,
   isPaused,
   isConnected,
+  gameEventNotificationsEnabled,
+  notificationPermission,
   showGameMenu,
   showResetConfirm,
   clearEventsOnReset,
@@ -64,6 +69,7 @@ export function GameHeader({
   onToggleMenu,
   onCloseMenu,
   onTogglePause,
+  onToggleGameEventNotifications,
   onStatsTrackingChange,
   onShowResetConfirm,
   onClearEventsChange,
@@ -200,6 +206,35 @@ export function GameHeader({
                         )}
                       </button>
                     )}
+
+                    <button
+                      onClick={() => {
+                        onToggleGameEventNotifications();
+                        onCloseMenu();
+                      }}
+                      disabled={notificationPermission === 'unsupported'}
+                      className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-50"
+                      type="button"
+                    >
+                      <svg
+                        className="h-4 w-4"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0a3 3 0 11-6 0m6 0H9"
+                        />
+                      </svg>
+                      {gameEventNotificationsEnabled
+                        ? 'Disable Game Alerts'
+                        : notificationPermission === 'denied'
+                          ? 'Notifications Blocked'
+                          : 'Enable Game Alerts'}
+                    </button>
 
                     {/* Stats Tracking Configuration */}
                     <div className="border-t border-gray-100">

--- a/apps/soccer-stats/ui/src/app/pwa/game-event-notifications.spec.ts
+++ b/apps/soccer-stats/ui/src/app/pwa/game-event-notifications.spec.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildGameEventNotification,
+  formatGameClock,
+  GameEventNotificationEvent,
+} from './game-event-notifications';
+
+const baseEvent = {
+  id: 'event-1',
+  gameTeamId: 'game-team-home',
+  period: '1',
+  periodSecond: 615,
+} satisfies Partial<GameEventNotificationEvent>;
+
+const baseContext = {
+  gameName: 'Mountain Lions vs River Hawks',
+  teamName: 'Mountain Lions',
+  opponentName: 'River Hawks',
+  teamType: 'home' as const,
+  homeScore: 2,
+  awayScore: 1,
+};
+
+describe('game event notifications', () => {
+  it('formats game clock values with period labels', () => {
+    expect(formatGameClock('1', 615)).toBe('1 10:15');
+    expect(formatGameClock(null, 59)).toBe('0:59');
+  });
+
+  it('builds a goal notification with scorer, assist, score, and game context', () => {
+    const notification = buildGameEventNotification(
+      {
+        ...baseEvent,
+        eventType: { name: 'GOAL' },
+        player: { firstName: 'Alex', lastName: 'Morgan' },
+        childEvents: [
+          {
+            eventType: { name: 'ASSIST' },
+            player: { firstName: 'Sam', lastName: 'Rivera' },
+          },
+        ],
+      } as GameEventNotificationEvent,
+      baseContext,
+    );
+
+    expect(notification).toEqual({
+      title: '⚽ Goal — Mountain Lions',
+      body: 'Mountain Lions vs River Hawks · 1 10:15\nScorer: Alex Morgan\nAssist: Sam Rivera\nScore: 2-1',
+      tag: 'soccer-stats:event-1',
+    });
+  });
+
+  it('builds substitution notifications for game events beyond goals', () => {
+    const notification = buildGameEventNotification(
+      {
+        ...baseEvent,
+        eventType: { name: 'SUBSTITUTION_IN' },
+        externalPlayerNumber: '12',
+      } as GameEventNotificationEvent,
+      baseContext,
+    );
+
+    expect(notification).toEqual({
+      title: 'Substitution — Mountain Lions',
+      body: '#12 on\nMountain Lions vs River Hawks · 1 10:15',
+      tag: 'soccer-stats:event-1',
+    });
+  });
+
+  it('ignores events that are not notification-worthy', () => {
+    expect(
+      buildGameEventNotification(
+        {
+          ...baseEvent,
+          eventType: { name: 'GAME_ROSTER' },
+        } as GameEventNotificationEvent,
+        baseContext,
+      ),
+    ).toBeNull();
+  });
+});

--- a/apps/soccer-stats/ui/src/app/pwa/game-event-notifications.ts
+++ b/apps/soccer-stats/ui/src/app/pwa/game-event-notifications.ts
@@ -1,0 +1,259 @@
+const NOTIFICATION_SETTING_KEY = 'soccer-stats:game-event-notifications';
+
+export type GameEventNotificationSetting = 'enabled' | 'disabled';
+
+export interface GameEventNotificationEvent {
+  id: string;
+  gameTeamId: string;
+  period?: string | null;
+  periodSecond: number;
+  eventType: { name: string };
+  player?: { firstName?: string | null; lastName?: string | null } | null;
+  externalPlayerName?: string | null;
+  externalPlayerNumber?: string | null;
+  position?: string | null;
+  formation?: string | null;
+  childEvents?: Array<{
+    eventType: { name: string };
+    player?: { firstName?: string | null; lastName?: string | null } | null;
+    externalPlayerName?: string | null;
+    externalPlayerNumber?: string | null;
+    position?: string | null;
+  }>;
+}
+
+export interface GameEventNotificationContext {
+  gameName: string;
+  teamName: string;
+  opponentName?: string;
+  teamType?: 'home' | 'away';
+  homeScore?: number;
+  awayScore?: number;
+}
+
+export function areGameEventNotificationsEnabled() {
+  return localStorage.getItem(NOTIFICATION_SETTING_KEY) === 'enabled';
+}
+
+export function setGameEventNotificationsEnabled(enabled: boolean) {
+  localStorage.setItem(
+    NOTIFICATION_SETTING_KEY,
+    enabled ? 'enabled' : 'disabled',
+  );
+}
+
+export function getNotificationPermission():
+  | NotificationPermission
+  | 'unsupported' {
+  if (!('Notification' in window)) {
+    return 'unsupported';
+  }
+  return Notification.permission;
+}
+
+export async function enableGameEventNotifications() {
+  if (!('Notification' in window)) {
+    setGameEventNotificationsEnabled(false);
+    return 'unsupported' as const;
+  }
+
+  const permission =
+    Notification.permission === 'default'
+      ? await Notification.requestPermission()
+      : Notification.permission;
+
+  const enabled = permission === 'granted';
+  setGameEventNotificationsEnabled(enabled);
+  return permission;
+}
+
+export function disableGameEventNotifications() {
+  setGameEventNotificationsEnabled(false);
+}
+
+export function formatGameClock(
+  period: string | null | undefined,
+  periodSecond: number,
+) {
+  const minutes = Math.floor(Math.max(0, periodSecond) / 60);
+  const seconds = Math.max(0, periodSecond) % 60;
+  const clock = `${minutes}:${seconds.toString().padStart(2, '0')}`;
+  return period ? `${period} ${clock}` : clock;
+}
+
+function formatPlayerName(event: GameEventNotificationEvent) {
+  const realName = [event.player?.firstName, event.player?.lastName]
+    .filter(Boolean)
+    .join(' ')
+    .trim();
+
+  if (realName) return realName;
+  if (event.externalPlayerName) return event.externalPlayerName;
+  if (event.externalPlayerNumber) return `#${event.externalPlayerNumber}`;
+  return null;
+}
+
+function formatChildPlayer(
+  child: NonNullable<GameEventNotificationEvent['childEvents']>[number],
+) {
+  const realName = [child.player?.firstName, child.player?.lastName]
+    .filter(Boolean)
+    .join(' ')
+    .trim();
+
+  if (realName) return realName;
+  if (child.externalPlayerName) return child.externalPlayerName;
+  if (child.externalPlayerNumber) return `#${child.externalPlayerNumber}`;
+  return null;
+}
+
+export function buildGameEventNotification(
+  event: GameEventNotificationEvent,
+  context: GameEventNotificationContext,
+): { title: string; body: string; tag: string } | null {
+  const eventType = event.eventType.name;
+  const clock = formatGameClock(event.period, event.periodSecond);
+  const playerName = formatPlayerName(event);
+  const score =
+    context.homeScore !== undefined && context.awayScore !== undefined
+      ? `Score: ${context.homeScore}-${context.awayScore}`
+      : undefined;
+  const tag = `soccer-stats:${event.id}`;
+
+  switch (eventType) {
+    case 'GOAL': {
+      const assist = event.childEvents
+        ?.filter((child) => child.eventType.name === 'ASSIST')
+        .map(formatChildPlayer)
+        .find(Boolean);
+      const details = [
+        playerName ? `Scorer: ${playerName}` : null,
+        assist ? `Assist: ${assist}` : null,
+        score,
+      ].filter(Boolean);
+
+      return {
+        title: `⚽ Goal — ${context.teamName}`,
+        body: [`${context.gameName} · ${clock}`, ...details].join('\n'),
+        tag,
+      };
+    }
+
+    case 'OWN_GOAL':
+      return {
+        title: `Own goal — ${context.teamName}`,
+        body: [
+          `${context.gameName} · ${clock}`,
+          playerName ? `Player: ${playerName}` : null,
+          score,
+        ]
+          .filter(Boolean)
+          .join('\n'),
+        tag,
+      };
+
+    case 'SUBSTITUTION_IN':
+      return {
+        title: `Substitution — ${context.teamName}`,
+        body: [
+          `${playerName ?? 'Player'} on`,
+          `${context.gameName} · ${clock}`,
+        ].join('\n'),
+        tag,
+      };
+
+    case 'SUBSTITUTION_OUT':
+      return {
+        title: `Substitution — ${context.teamName}`,
+        body: [
+          `${playerName ?? 'Player'} off`,
+          `${context.gameName} · ${clock}`,
+        ].join('\n'),
+        tag,
+      };
+
+    case 'PERIOD_START':
+      return {
+        title: `${context.gameName} resumed`,
+        body: `${context.teamName} · ${clock}`,
+        tag,
+      };
+
+    case 'PERIOD_END':
+      return {
+        title: `${context.gameName} period ended`,
+        body: `${context.teamName} · ${clock}`,
+        tag,
+      };
+
+    case 'FORMATION_CHANGE':
+      return {
+        title: `Formation change — ${context.teamName}`,
+        body: [event.formation, `${context.gameName} · ${clock}`]
+          .filter(Boolean)
+          .join('\n'),
+        tag,
+      };
+
+    case 'POSITION_CHANGE':
+      return {
+        title: `Position change — ${context.teamName}`,
+        body: [
+          playerName
+            ? `${playerName}${event.position ? ` → ${event.position}` : ''}`
+            : null,
+          `${context.gameName} · ${clock}`,
+        ]
+          .filter(Boolean)
+          .join('\n'),
+        tag,
+      };
+
+    case 'YELLOW_CARD':
+    case 'RED_CARD':
+      return {
+        title: `${eventType.replace('_', ' ')} — ${context.teamName}`,
+        body: [playerName, `${context.gameName} · ${clock}`]
+          .filter(Boolean)
+          .join('\n'),
+        tag,
+      };
+
+    default:
+      return null;
+  }
+}
+
+export async function notifyGameEvent(
+  event: GameEventNotificationEvent,
+  context: GameEventNotificationContext,
+) {
+  if (!areGameEventNotificationsEnabled()) return false;
+  if (!('Notification' in window) || Notification.permission !== 'granted') {
+    return false;
+  }
+
+  const notification = buildGameEventNotification(event, context);
+  if (!notification) return false;
+
+  const options: NotificationOptions = {
+    body: notification.body,
+    tag: notification.tag,
+    icon: '/icons/icon-192.png',
+    badge: '/icons/icon-192.png',
+  };
+
+  try {
+    if ('serviceWorker' in navigator) {
+      const registration = await navigator.serviceWorker.ready;
+      await registration.showNotification(notification.title, options);
+      return true;
+    }
+
+    new Notification(notification.title, options);
+    return true;
+  } catch (error) {
+    console.error('Failed to show game event notification:', error);
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds opt-in PWA/browser game alerts from the existing `gameEventChanged` live subscription
- Adds a Game Options menu item to enable/disable game alerts and request browser notification permission explicitly
- Sends notifications for goals plus other noteworthy game events: own goals, substitutions, period start/end, formation/position changes, and cards
- Includes scorer, assist, game clock, team, and score details when available

## Test Plan
- [x] pnpm nx test soccer-stats-ui --testFile=apps/soccer-stats/ui/src/app/pwa/game-event-notifications.spec.ts --skip-nx-cache
- [x] pnpm nx lint soccer-stats-ui
- [x] pnpm nx build soccer-stats-ui --skip-nx-cache

## Notes
- This is local/browser notification support while the PWA/app is running and receiving the live subscription. Full push notifications when the app is fully closed would require backend Push API subscription storage, VAPID keys, and server-side web-push delivery.
- UI lint passes with existing warnings.
- UI build still reports existing large chunk and stale Browserslist warnings.
