### PR TITLE
feat(soccer-stats): add calendar import UI

### DIFF
--- a/apps/soccer-stats/ui/src/app/components/presentation/team-settings.presentation.spec.tsx
+++ b/apps/soccer-stats/ui/src/app/components/presentation/team-settings.presentation.spec.tsx
@@ -1,0 +1,113 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { UITeam } from '../types/ui.types';
+
+import { TeamSettingsPresentation } from './team-settings.presentation';
+
+const team: UITeam = {
+  id: 'team-1',
+  name: 'Mountain Lions',
+  shortName: 'Lions',
+  description: '',
+  homePrimaryColor: '#2563eb',
+  homeSecondaryColor: '#ffffff',
+  awayPrimaryColor: '#ffffff',
+  awaySecondaryColor: '#2563eb',
+  logoUrl: '',
+  isActive: true,
+  isManaged: true,
+  sourceType: 'INTERNAL',
+};
+
+const baseProps = {
+  team,
+  selectedGameFormat: '7v7',
+  selectedFormation: '2-3-1',
+  statsFeatures: {
+    trackGoals: true,
+    trackScorer: true,
+    trackAssists: true,
+    trackSubstitutions: true,
+    trackPositions: true,
+  },
+  gameFormats: [],
+  formations: [],
+  positions: [],
+  calendarSources: [],
+  calendarSourcesLoading: false,
+  creatingCalendarSource: false,
+  syncingCalendarSource: false,
+  onCreateCalendarSource: vi.fn(),
+  onSyncCalendarSource: vi.fn(),
+  onSaveSettings: vi.fn(),
+  onGameFormatSelect: vi.fn(),
+  onFormationSelect: vi.fn(),
+  onStatsFeaturesChange: vi.fn(),
+  onPositionUpdate: vi.fn(),
+  onAddPosition: vi.fn(),
+  onRemovePosition: vi.fn(),
+  loading: false,
+};
+
+describe('TeamSettingsPresentation calendar import', () => {
+  it('renders an empty-state calendar import form', () => {
+    render(<TeamSettingsPresentation {...baseProps} />);
+
+    expect(screen.getByText('Calendar Import')).toBeTruthy();
+    expect(screen.getByLabelText('PlayMetrics calendar URL')).toBeTruthy();
+    expect(screen.getByText('No calendar feeds connected yet')).toBeTruthy();
+  });
+
+  it('submits a trimmed ICS feed URL', () => {
+    const onCreateCalendarSource = vi.fn();
+    render(
+      <TeamSettingsPresentation
+        {...baseProps}
+        onCreateCalendarSource={onCreateCalendarSource}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText('PlayMetrics calendar URL'), {
+      target: {
+        value:
+          '  https://calendar.playmetrics.com/calendars/team/games-calendar.ics  ',
+      },
+    });
+    fireEvent.click(screen.getByText('Connect Feed'));
+
+    expect(onCreateCalendarSource).toHaveBeenCalledWith(
+      'https://calendar.playmetrics.com/calendars/team/games-calendar.ics',
+    );
+  });
+
+  it('renders connected feeds and syncs a selected source', () => {
+    const onSyncCalendarSource = vi.fn();
+    render(
+      <TeamSettingsPresentation
+        {...baseProps}
+        calendarSources={[
+          {
+            id: 'source-1',
+            teamId: 'team-1',
+            provider: 'PLAYMETRICS',
+            feedUrl:
+              'https://calendar.playmetrics.com/calendars/team/games-calendar.ics',
+            calendarName: 'Mountain Lions Games',
+            enabled: true,
+            lastSyncedAt: '2026-07-18T12:00:00.000Z',
+            lastSyncStatus: 'SUCCESS',
+          },
+        ]}
+        onSyncCalendarSource={onSyncCalendarSource}
+      />,
+    );
+
+    expect(screen.getByText('Mountain Lions Games')).toBeTruthy();
+    expect(screen.getByText('Enabled')).toBeTruthy();
+    expect(screen.getByText('Success')).toBeTruthy();
+
+    fireEvent.click(screen.getByText('Sync Now'));
+    expect(onSyncCalendarSource).toHaveBeenCalledWith('source-1');
+  });
+});

--- a/apps/soccer-stats/ui/src/app/components/presentation/team-settings.presentation.tsx
+++ b/apps/soccer-stats/ui/src/app/components/presentation/team-settings.presentation.tsx
@@ -7,6 +7,7 @@ import {
   type UIStatsFeatures,
 } from '@garage/soccer-stats/ui-components';
 
+import { CalendarSourceViewModel } from '../../services/calendar-sync-graphql.service';
 import { UITeam, UIGameFormat, UIFormation } from '../types/ui.types';
 
 import { StatsTrackingSelector } from './stats-tracking-selector.presentation';
@@ -25,6 +26,15 @@ interface TeamSettingsPresentationProps {
     x: number;
     y: number;
   }>;
+  calendarSources: CalendarSourceViewModel[];
+  calendarSourcesLoading: boolean;
+  calendarSourcesError?: string;
+  creatingCalendarSource: boolean;
+  syncingCalendarSource: boolean;
+  calendarSuccessMessage?: string;
+  calendarErrorMessage?: string;
+  onCreateCalendarSource: (feedUrl: string) => void;
+  onSyncCalendarSource: (sourceId: string) => void;
   onSaveSettings: (settingsData: {
     basicInfo: UICreateTeamInput;
     gameFormat?: string;
@@ -66,6 +76,15 @@ export const TeamSettingsPresentation = ({
   gameFormats,
   formations,
   positions,
+  calendarSources,
+  calendarSourcesLoading,
+  calendarSourcesError,
+  creatingCalendarSource,
+  syncingCalendarSource,
+  calendarSuccessMessage,
+  calendarErrorMessage,
+  onCreateCalendarSource,
+  onSyncCalendarSource,
   onSaveSettings,
   onGameFormatSelect,
   onFormationSelect,
@@ -89,8 +108,11 @@ export const TeamSettingsPresentation = ({
           logoUrl: '',
         },
   );
+  const [calendarFeedUrl, setCalendarFeedUrl] = useState('');
 
-  // Update form data when team changes
+  const normalizedCalendarFeedUrl = calendarFeedUrl.trim();
+  const canCreateCalendarSource =
+    normalizedCalendarFeedUrl.length > 0 && !creatingCalendarSource;
   useEffect(() => {
     if (team) {
       setBasicInfo(createTeamFormValues(team));
@@ -115,6 +137,35 @@ export const TeamSettingsPresentation = ({
     positions,
     onSaveSettings,
   ]);
+
+  const handleCreateCalendarSource = useCallback(() => {
+    if (!canCreateCalendarSource) return;
+    onCreateCalendarSource(normalizedCalendarFeedUrl);
+    setCalendarFeedUrl('');
+  }, [
+    canCreateCalendarSource,
+    normalizedCalendarFeedUrl,
+    onCreateCalendarSource,
+  ]);
+
+  const formatSyncStatus = (status: string) =>
+    status
+      .replace(/_/g, ' ')
+      .toLowerCase()
+      .replace(/^./, (char) => char.toUpperCase());
+
+  const formatProvider = (provider: string) => {
+    if (provider.toLowerCase() === 'playmetrics') return 'PlayMetrics';
+    return provider.replace(/_/g, ' ');
+  };
+
+  const formatSyncedAt = (value?: string | null) => {
+    if (!value) return 'Never synced';
+    return new Intl.DateTimeFormat(undefined, {
+      dateStyle: 'medium',
+      timeStyle: 'short',
+    }).format(new Date(value));
+  };
 
   return (
     <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
@@ -329,6 +380,164 @@ export const TeamSettingsPresentation = ({
             </div>
           </div>
         )}
+
+        {/* Calendar Import */}
+        <div className="space-y-6 rounded-2xl border border-slate-200 bg-slate-50 p-5">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+            <div>
+              <h3 className="text-lg font-semibold text-slate-950">
+                Calendar Import
+              </h3>
+              <p className="mt-1 max-w-2xl text-sm text-slate-600">
+                Connect a PlayMetrics ICS calendar feed to import scheduled
+                games for this team. Imports are idempotent, so syncing the same
+                feed again updates existing games instead of duplicating them.
+              </p>
+            </div>
+            <span className="inline-flex w-fit rounded-full bg-blue-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-blue-700">
+              ICS
+            </span>
+          </div>
+
+          <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+            <label
+              htmlFor="calendar-feed-url"
+              className="text-sm font-semibold text-slate-800"
+            >
+              PlayMetrics calendar URL
+            </label>
+            <div className="mt-2 flex flex-col gap-3 lg:flex-row">
+              <input
+                id="calendar-feed-url"
+                type="url"
+                value={calendarFeedUrl}
+                onChange={(event) => setCalendarFeedUrl(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter') {
+                    event.preventDefault();
+                    handleCreateCalendarSource();
+                  }
+                }}
+                placeholder="https://calendar.playmetrics.com/calendars/.../games-calendar.ics"
+                className="min-h-[44px] flex-1 rounded-xl border border-slate-300 px-3 py-2 text-sm text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-100"
+                disabled={creatingCalendarSource}
+              />
+              <button
+                type="button"
+                onClick={handleCreateCalendarSource}
+                disabled={!canCreateCalendarSource}
+                className="inline-flex min-h-[44px] items-center justify-center rounded-xl bg-blue-600 px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:bg-slate-300 disabled:text-slate-500"
+              >
+                {creatingCalendarSource ? 'Connecting…' : 'Connect Feed'}
+              </button>
+            </div>
+            <p className="mt-2 text-xs text-slate-500">
+              Paste the team games `.ics` URL. The backend validates the URL and
+              fetches the feed server-side.
+            </p>
+          </div>
+
+          {(calendarSourcesError || calendarErrorMessage) && (
+            <div className="whitespace-pre-wrap rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-800">
+              {calendarErrorMessage || calendarSourcesError}
+            </div>
+          )}
+
+          {calendarSuccessMessage && (
+            <div className="rounded-xl border border-emerald-200 bg-emerald-50 p-4 text-sm font-medium text-emerald-800">
+              {calendarSuccessMessage}
+            </div>
+          )}
+
+          <div className="space-y-3">
+            <div className="flex items-center justify-between gap-3">
+              <h4 className="text-sm font-semibold uppercase tracking-wide text-slate-500">
+                Connected feeds
+              </h4>
+              {calendarSourcesLoading && (
+                <span className="text-xs text-slate-500">Loading…</span>
+              )}
+            </div>
+
+            {!calendarSourcesLoading && calendarSources.length === 0 ? (
+              <div className="rounded-xl border border-dashed border-slate-300 bg-white p-6 text-center">
+                <p className="font-semibold text-slate-900">
+                  No calendar feeds connected yet
+                </p>
+                <p className="mt-1 text-sm text-slate-600">
+                  Add the first PlayMetrics ICS feed above, then run Sync Now to
+                  import this team's schedule.
+                </p>
+              </div>
+            ) : (
+              <div className="space-y-3">
+                {calendarSources.map((source) => {
+                  const isError =
+                    source.lastSyncStatus.toLowerCase() === 'error';
+                  const isSuccess =
+                    source.lastSyncStatus.toLowerCase() === 'success';
+
+                  return (
+                    <div
+                      key={source.id}
+                      className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm"
+                    >
+                      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                        <div className="min-w-0 flex-1">
+                          <div className="flex flex-wrap items-center gap-2">
+                            <p className="font-semibold text-slate-950">
+                              {source.calendarName ||
+                                `${formatProvider(source.provider)} calendar`}
+                            </p>
+                            <span
+                              className={`rounded-full px-2.5 py-0.5 text-xs font-semibold ${
+                                source.enabled
+                                  ? 'bg-emerald-100 text-emerald-700'
+                                  : 'bg-slate-100 text-slate-600'
+                              }`}
+                            >
+                              {source.enabled ? 'Enabled' : 'Disabled'}
+                            </span>
+                            <span
+                              className={`rounded-full px-2.5 py-0.5 text-xs font-semibold ${
+                                isError
+                                  ? 'bg-red-100 text-red-700'
+                                  : isSuccess
+                                    ? 'bg-blue-100 text-blue-700'
+                                    : 'bg-slate-100 text-slate-600'
+                              }`}
+                            >
+                              {formatSyncStatus(source.lastSyncStatus)}
+                            </span>
+                          </div>
+                          <p className="mt-2 truncate text-sm text-slate-600">
+                            {source.feedUrl}
+                          </p>
+                          <p className="mt-2 text-xs text-slate-500">
+                            Last sync: {formatSyncedAt(source.lastSyncedAt)}
+                          </p>
+                          {source.lastSyncError && (
+                            <p className="mt-2 rounded-lg bg-red-50 px-3 py-2 text-xs text-red-700">
+                              {source.lastSyncError}
+                            </p>
+                          )}
+                        </div>
+                        <button
+                          type="button"
+                          onClick={() => onSyncCalendarSource(source.id)}
+                          disabled={syncingCalendarSource}
+                          className="inline-flex min-h-[44px] items-center justify-center rounded-xl border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm transition hover:border-blue-300 hover:bg-blue-50 hover:text-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                        >
+                          {syncingCalendarSource ? 'Syncing…' : 'Sync Now'}
+                        </button>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        </div>
 
         {/* Error Display */}
         {error && (

--- a/apps/soccer-stats/ui/src/app/components/smart/team-settings.smart.tsx
+++ b/apps/soccer-stats/ui/src/app/components/smart/team-settings.smart.tsx
@@ -21,6 +21,14 @@ import {
   GET_TEAMS,
 } from '../../services/teams-graphql.service';
 import { GET_GAME_FORMATS } from '../../services/games-graphql.service';
+import {
+  CREATE_TEAM_CALENDAR_SOURCE,
+  CreateTeamCalendarSourceResponse,
+  SYNC_TEAM_CALENDAR_SOURCE,
+  SyncTeamCalendarSourceResponse,
+  TEAM_CALENDAR_SOURCES,
+  TeamCalendarSourcesResponse,
+} from '../../services/calendar-sync-graphql.service';
 import { TeamSettingsPresentation } from '../presentation/team-settings.presentation';
 import { UICreateTeamInput, UIPosition } from '../types/ui.types';
 
@@ -29,6 +37,9 @@ import { useTeamConfigurationManager } from './team-configuration-manager.smart'
 export const TeamSettingsSmart = () => {
   const { teamId } = useParams<{ teamId: string }>();
   const [saveSuccess, setSaveSuccess] = useState(false);
+  const [calendarSuccessMessage, setCalendarSuccessMessage] =
+    useState<string>();
+  const [calendarErrorMessage, setCalendarErrorMessage] = useState<string>();
   const [statsFeatures, setStatsFeatures] = useState<UIStatsFeatures>(
     UI_DEFAULT_STATS_FEATURES,
   );
@@ -60,6 +71,31 @@ export const TeamSettingsSmart = () => {
   const { data: gameFormatsData } = useQuery<{ gameFormats: GameFormat[] }>(
     GET_GAME_FORMATS,
   );
+
+  const {
+    data: calendarSourcesData,
+    loading: calendarSourcesLoading,
+    error: calendarSourcesError,
+  } = useQuery<TeamCalendarSourcesResponse>(TEAM_CALENDAR_SOURCES, {
+    variables: { teamId },
+    skip: !teamId,
+  });
+
+  const [createCalendarSource, { loading: creatingCalendarSource }] =
+    useMutation<CreateTeamCalendarSourceResponse>(CREATE_TEAM_CALENDAR_SOURCE, {
+      refetchQueries: [
+        { query: TEAM_CALENDAR_SOURCES, variables: { teamId } },
+        { query: GET_TEAM_BY_ID, variables: { id: teamId } },
+      ],
+    });
+
+  const [syncCalendarSource, { loading: syncingCalendarSource }] =
+    useMutation<SyncTeamCalendarSourceResponse>(SYNC_TEAM_CALENDAR_SOURCE, {
+      refetchQueries: [
+        { query: TEAM_CALENDAR_SOURCES, variables: { teamId } },
+        { query: GET_TEAM_BY_ID, variables: { id: teamId } },
+      ],
+    });
 
   // Update team mutation
   const [updateTeam, { loading: updateLoading, error: updateError }] =
@@ -201,6 +237,70 @@ export const TeamSettingsSmart = () => {
     [teamId, updateTeam, updateTeamConfiguration, gameFormatsData],
   );
 
+  const handleCreateCalendarSource = useCallback(
+    async (feedUrl: string) => {
+      if (!teamId) return;
+
+      setCalendarErrorMessage(undefined);
+      setCalendarSuccessMessage(undefined);
+
+      try {
+        await createCalendarSource({
+          variables: {
+            input: {
+              teamId,
+              provider: 'PLAYMETRICS',
+              feedUrl,
+              enabled: true,
+            },
+          },
+        });
+        setCalendarSuccessMessage('Calendar feed connected.');
+      } catch (err) {
+        setCalendarErrorMessage(
+          err instanceof Error
+            ? err.message
+            : 'Failed to connect calendar feed',
+        );
+      }
+    },
+    [createCalendarSource, teamId],
+  );
+
+  const handleSyncCalendarSource = useCallback(
+    async (sourceId: string) => {
+      if (!teamId) return;
+
+      setCalendarErrorMessage(undefined);
+      setCalendarSuccessMessage(undefined);
+
+      try {
+        const result = await syncCalendarSource({
+          variables: { teamId, sourceId },
+        });
+        const syncResult = result.data?.syncTeamCalendarSource;
+        if (syncResult) {
+          const summary = [
+            `${syncResult.created} created`,
+            `${syncResult.updated} updated`,
+            `${syncResult.skipped} skipped`,
+          ].join(', ');
+          setCalendarSuccessMessage(`Calendar sync complete: ${summary}.`);
+          if (syncResult.errors.length > 0) {
+            setCalendarErrorMessage(syncResult.errors.join('\n'));
+          }
+        } else {
+          setCalendarSuccessMessage('Calendar sync complete.');
+        }
+      } catch (err) {
+        setCalendarErrorMessage(
+          err instanceof Error ? err.message : 'Failed to sync calendar feed',
+        );
+      }
+    },
+    [syncCalendarSource, teamId],
+  );
+
   // Show loading state for fetching
   if (fetchLoading) {
     return (
@@ -252,6 +352,15 @@ export const TeamSettingsSmart = () => {
       gameFormats={gameFormats}
       formations={availableFormations}
       positions={positions}
+      calendarSources={calendarSourcesData?.teamCalendarSources ?? []}
+      calendarSourcesLoading={calendarSourcesLoading}
+      calendarSourcesError={calendarSourcesError?.message}
+      creatingCalendarSource={creatingCalendarSource}
+      syncingCalendarSource={syncingCalendarSource}
+      calendarSuccessMessage={calendarSuccessMessage}
+      calendarErrorMessage={calendarErrorMessage}
+      onCreateCalendarSource={handleCreateCalendarSource}
+      onSyncCalendarSource={handleSyncCalendarSource}
       onSaveSettings={handleSaveSettings}
       onGameFormatSelect={selectGameFormat}
       onFormationSelect={selectFormation}

--- a/apps/soccer-stats/ui/src/app/services/calendar-sync-graphql.service.ts
+++ b/apps/soccer-stats/ui/src/app/services/calendar-sync-graphql.service.ts
@@ -1,6 +1,5 @@
+import { gql } from '@apollo/client';
 import type { TypedDocumentNode } from '@graphql-typed-document-node/core';
-
-import { graphql } from '@garage/soccer-stats/graphql-codegen';
 
 export interface CalendarSourceViewModel {
   id: string;
@@ -59,7 +58,7 @@ interface SyncTeamCalendarSourceVariables {
   sourceId: string;
 }
 
-export const TEAM_CALENDAR_SOURCES = graphql(/* GraphQL */ `
+export const TEAM_CALENDAR_SOURCES = gql`
   query TeamCalendarSources($teamId: ID!) {
     teamCalendarSources(teamId: $teamId) {
       id
@@ -75,12 +74,12 @@ export const TEAM_CALENDAR_SOURCES = graphql(/* GraphQL */ `
       updatedAt
     }
   }
-`) as TypedDocumentNode<
+` as TypedDocumentNode<
   TeamCalendarSourcesResponse,
   TeamCalendarSourcesVariables
 >;
 
-export const CREATE_TEAM_CALENDAR_SOURCE = graphql(/* GraphQL */ `
+export const CREATE_TEAM_CALENDAR_SOURCE = gql`
   mutation CreateTeamCalendarSource($input: CreateCalendarSourceInput!) {
     createTeamCalendarSource(input: $input) {
       id
@@ -96,12 +95,12 @@ export const CREATE_TEAM_CALENDAR_SOURCE = graphql(/* GraphQL */ `
       updatedAt
     }
   }
-`) as TypedDocumentNode<
+` as TypedDocumentNode<
   CreateTeamCalendarSourceResponse,
   CreateTeamCalendarSourceVariables
 >;
 
-export const SYNC_TEAM_CALENDAR_SOURCE = graphql(/* GraphQL */ `
+export const SYNC_TEAM_CALENDAR_SOURCE = gql`
   mutation SyncTeamCalendarSource($teamId: ID!, $sourceId: ID!) {
     syncTeamCalendarSource(teamId: $teamId, sourceId: $sourceId) {
       sourceId
@@ -111,7 +110,7 @@ export const SYNC_TEAM_CALENDAR_SOURCE = graphql(/* GraphQL */ `
       errors
     }
   }
-`) as TypedDocumentNode<
+` as TypedDocumentNode<
   SyncTeamCalendarSourceResponse,
   SyncTeamCalendarSourceVariables
 >;

--- a/apps/soccer-stats/ui/src/app/services/calendar-sync-graphql.service.ts
+++ b/apps/soccer-stats/ui/src/app/services/calendar-sync-graphql.service.ts
@@ -1,0 +1,117 @@
+import type { TypedDocumentNode } from '@graphql-typed-document-node/core';
+
+import { graphql } from '@garage/soccer-stats/graphql-codegen';
+
+export interface CalendarSourceViewModel {
+  id: string;
+  teamId: string;
+  provider: 'PLAYMETRICS' | 'playmetrics' | string;
+  feedUrl: string;
+  calendarName?: string | null;
+  enabled: boolean;
+  lastSyncedAt?: string | null;
+  lastSyncStatus:
+    | 'NEVER_SYNCED'
+    | 'SUCCESS'
+    | 'ERROR'
+    | 'never_synced'
+    | 'success'
+    | 'error'
+    | string;
+  lastSyncError?: string | null;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface TeamCalendarSourcesResponse {
+  teamCalendarSources: CalendarSourceViewModel[];
+}
+
+export interface CreateTeamCalendarSourceResponse {
+  createTeamCalendarSource: CalendarSourceViewModel;
+}
+
+export interface SyncTeamCalendarSourceResponse {
+  syncTeamCalendarSource: {
+    sourceId: string;
+    created: number;
+    updated: number;
+    skipped: number;
+    errors: string[];
+  };
+}
+
+interface TeamCalendarSourcesVariables {
+  teamId: string;
+}
+
+interface CreateTeamCalendarSourceVariables {
+  input: {
+    teamId: string;
+    provider: 'PLAYMETRICS';
+    feedUrl: string;
+    enabled: boolean;
+  };
+}
+
+interface SyncTeamCalendarSourceVariables {
+  teamId: string;
+  sourceId: string;
+}
+
+export const TEAM_CALENDAR_SOURCES = graphql(/* GraphQL */ `
+  query TeamCalendarSources($teamId: ID!) {
+    teamCalendarSources(teamId: $teamId) {
+      id
+      teamId
+      provider
+      feedUrl
+      calendarName
+      enabled
+      lastSyncedAt
+      lastSyncStatus
+      lastSyncError
+      createdAt
+      updatedAt
+    }
+  }
+`) as TypedDocumentNode<
+  TeamCalendarSourcesResponse,
+  TeamCalendarSourcesVariables
+>;
+
+export const CREATE_TEAM_CALENDAR_SOURCE = graphql(/* GraphQL */ `
+  mutation CreateTeamCalendarSource($input: CreateCalendarSourceInput!) {
+    createTeamCalendarSource(input: $input) {
+      id
+      teamId
+      provider
+      feedUrl
+      calendarName
+      enabled
+      lastSyncedAt
+      lastSyncStatus
+      lastSyncError
+      createdAt
+      updatedAt
+    }
+  }
+`) as TypedDocumentNode<
+  CreateTeamCalendarSourceResponse,
+  CreateTeamCalendarSourceVariables
+>;
+
+export const SYNC_TEAM_CALENDAR_SOURCE = graphql(/* GraphQL */ `
+  mutation SyncTeamCalendarSource($teamId: ID!, $sourceId: ID!) {
+    syncTeamCalendarSource(teamId: $teamId, sourceId: $sourceId) {
+      sourceId
+      created
+      updated
+      skipped
+      errors
+    }
+  }
+`) as TypedDocumentNode<
+  SyncTeamCalendarSourceResponse,
+  SyncTeamCalendarSourceVariables
+>;


### PR DESCRIPTION
## Summary
- Adds a Team Settings Calendar Import section for connecting PlayMetrics ICS feeds
- Wires the UI to backend GraphQL calendar-source query/create/sync operations
- Shows connected feeds, enabled/sync status, last sync time, sync errors, and sync result feedback
- Adds presentation tests for the calendar import empty state, feed submission, and manual sync

## Verification
- `pnpm nx test soccer-stats-ui --testFile=apps/soccer-stats/ui/src/app/components/presentation/team-settings.presentation.spec.tsx --skip-nx-cache`
- `pnpm nx lint soccer-stats-ui`
- `pnpm nx build soccer-stats-ui --skip-nx-cache`

## Notes
- This is the first UI layer over the existing backend ICS import functionality.
- Feed deletion/enable-disable editing is not included because the backend currently exposes query/create/sync only.
