### PR TITLE
fix(soccer-stats-api): resolve TeamAccessGuard DI failure in CalendarSyncModule

### DIFF
--- a/apps/soccer-stats/api/src/modules/calendar-sync/calendar-sync.module.ts
+++ b/apps/soccer-stats/api/src/modules/calendar-sync/calendar-sync.module.ts
@@ -9,6 +9,7 @@ import { GameFormat } from '../../entities/game-format.entity';
 import { Team } from '../../entities/team.entity';
 import { TeamConfiguration } from '../../entities/team-configuration.entity';
 import { AuthModule } from '../auth/auth.module';
+import { TeamMembersModule } from '../team-members/team-members.module';
 
 import { CalendarSyncResolver } from './calendar-sync.resolver';
 import { CalendarSyncSchedulerService } from './calendar-sync-scheduler.service';
@@ -27,6 +28,9 @@ import { PlayMetricsIcsParserService } from './playmetrics-ics-parser.service';
       TeamConfiguration,
     ]),
     AuthModule,
+    // TeamAccessGuard is instantiated in this module's context via @UseGuards,
+    // so its TeamMembersService dependency must be resolvable here
+    TeamMembersModule,
   ],
   providers: [
     CalendarSyncResolver,


### PR DESCRIPTION
## Problem

Every soccer-stats deploy since PR #275 (playmetrics-calendar-sync) has failed — the CD `verify` step times out after 5 minutes with `/api/version` returning `text/html` ([latest failed run](https://github.com/JoA-MoS/garage/actions/runs/29665421681/job/88134932246)).

## Root cause

`CalendarSyncResolver` applies `TeamAccessGuard` via `@UseGuards`, and NestJS instantiates guard enhancers in the **consuming module's** DI context. `CalendarSyncModule` never imported `TeamMembersModule`, so the guard's `TeamMembersService` dependency could not resolve and the app crashed at bootstrap:

```
UnknownDependenciesException: Nest can't resolve dependencies of the TeamAccessGuard (Reflector, ?).
Please make sure that the argument TeamMembersService at index [1] is available in the CalendarSyncModule context.
```

Failure chain in dev:
1. New App Runner container crashes at bootstrap → health check fails
2. App Runner auto-rolls back (`ROLLBACK_SUCCEEDED` on every `UPDATE_SERVICE` since Jul 15) and keeps serving the last good container from Jul 15
3. That stale container 404s `/api/version` → CloudFront's SPA custom error response rewrites it to `index.html` (200, `text/html`) → CD verify step fails

CI never caught it because unit tests mock services and nothing boots the real module graph.

## Fix

Import `TeamMembersModule` into `CalendarSyncModule` — the same pattern `TeamsModule` uses for the same guard.

## Verification

- Without the fix, `nx serve soccer-stats-api` reproduces the exact `UnknownDependenciesException` locally
- With the fix, the app boots cleanly (`Nest application successfully started`), `/api/health` → 200 and `/api/version` → 200 `application/json`
- `nx run-many --target=test,lint --projects=soccer-stats-api` passes

## Follow-ups (not in this PR)

- Add a smoke test that compiles the full `AppModule` graph so DI wiring errors fail CI instead of prod deploys
- The CD verify failure surfaced the issue but the Pulumi `up` still reported success while App Runner rolled back; consider checking the App Runner operation status after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014AEbsiQHuMnoFoe8Wq1Hau