### PR TITLE
fix(soccer-stats-api): require auth on all GraphQL mutations

### DIFF
--- a/apps/soccer-stats/api/src/modules/auth/mutation-auth.architectural.spec.ts
+++ b/apps/soccer-stats/api/src/modules/auth/mutation-auth.architectural.spec.ts
@@ -1,0 +1,130 @@
+import 'reflect-metadata';
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { IS_PUBLIC_KEY } from './public.decorator';
+
+/**
+ * Architectural Test: Mutation Auth Enforcement (#285)
+ *
+ * Every GraphQL mutation must require authentication. ClerkAuthGuard is
+ * applied at the resolver class level, and @Public() opts a handler out of
+ * it — which is acceptable for read queries and subscriptions, but never
+ * for mutations on a publicly deployed API.
+ *
+ * WHY THIS MATTERS:
+ * - The API is exposed publicly (App Runner + CloudFront)
+ * - A @Public() mutation lets anyone create, modify, or delete game data
+ *   without a token
+ *
+ * This spec discovers every *.resolver.ts file under src/modules, loads its
+ * exported classes, and asserts that no method decorated with @Mutation()
+ * also carries @Public() metadata — the same metadata ClerkAuthGuard's
+ * Reflector reads at runtime.
+ */
+describe('Mutation Auth Architecture', () => {
+  // Set by @Mutation() via addResolverMetadata (see @nestjs/graphql
+  // resolvers.utils). Value is Resolver.MUTATION = 'Mutation'.
+  const RESOLVER_TYPE_METADATA = 'graphql:resolver_type';
+
+  const modulesDir = path.join(__dirname, '..');
+
+  function findResolverFiles(dir: string): string[] {
+    const files: string[] = [];
+
+    function walk(currentDir: string) {
+      const entries = fs.readdirSync(currentDir, { withFileTypes: true });
+      for (const entry of entries) {
+        const fullPath = path.join(currentDir, entry.name);
+        if (entry.isDirectory()) {
+          walk(fullPath);
+        } else if (entry.isFile() && /\.resolver\.ts$/.test(entry.name)) {
+          files.push(fullPath);
+        }
+      }
+    }
+
+    walk(dir);
+    return files;
+  }
+
+  it('should not have any @Public() mutations', () => {
+    const resolverFiles = findResolverFiles(modulesDir);
+    expect(resolverFiles.length).toBeGreaterThan(0);
+
+    const violations: { file: string; method: string; mutation: string }[] = [];
+    let mutationsChecked = 0;
+
+    for (const file of resolverFiles) {
+      const moduleExports = require(file) as Record<string, unknown>;
+
+      for (const exported of Object.values(moduleExports)) {
+        if (typeof exported !== 'function' || !exported.prototype) {
+          continue;
+        }
+
+        for (const methodName of Object.getOwnPropertyNames(
+          exported.prototype,
+        )) {
+          if (methodName === 'constructor') {
+            continue;
+          }
+          const handler = exported.prototype[methodName];
+          if (typeof handler !== 'function') {
+            continue;
+          }
+
+          const resolverType = Reflect.getMetadata(
+            RESOLVER_TYPE_METADATA,
+            handler,
+          );
+          if (resolverType !== 'Mutation') {
+            continue;
+          }
+          mutationsChecked++;
+
+          if (Reflect.getMetadata(IS_PUBLIC_KEY, handler) === true) {
+            violations.push({
+              file: path.relative(modulesDir, file),
+              method: `${exported.name}.${methodName}`,
+              mutation:
+                Reflect.getMetadata('graphql:resolver_name', handler) ??
+                methodName,
+            });
+          }
+        }
+      }
+    }
+
+    // Sanity check that metadata discovery actually found the app's mutations
+    // (guards against silent breakage if @nestjs/graphql changes its keys).
+    expect(mutationsChecked).toBeGreaterThan(10);
+
+    if (violations.length > 0) {
+      const message = [
+        '',
+        '❌ ARCHITECTURAL VIOLATION: @Public() mutations detected!',
+        '',
+        'The following mutations can be called without authentication:',
+        '',
+        ...violations.map(
+          (v) => `  📁 ${v.file} → ${v.method} (${v.mutation})`,
+        ),
+        '',
+        'WHY THIS BREAKS SECURITY:',
+        '  - The API is deployed publicly; anyone can call these mutations',
+        '  - @Public() bypasses the class-level ClerkAuthGuard',
+        '',
+        'HOW TO FIX:',
+        '  1. Remove @Public() from the mutation handler',
+        '  2. The class-level @UseGuards(ClerkAuthGuard) then enforces auth',
+        '  3. Add @CurrentUser() if the handler needs the acting user',
+        '',
+        'See issue #285.',
+        '',
+      ].join('\n');
+
+      throw new Error(message);
+    }
+  });
+});

--- a/apps/soccer-stats/api/src/modules/auth/mutation-auth.architectural.spec.ts
+++ b/apps/soccer-stats/api/src/modules/auth/mutation-auth.architectural.spec.ts
@@ -20,7 +20,9 @@ import { IS_PUBLIC_KEY } from './public.decorator';
  * This spec discovers every *.resolver.ts file under src/modules, loads its
  * exported classes, and asserts that no method decorated with @Mutation()
  * also carries @Public() metadata — the same metadata ClerkAuthGuard's
- * Reflector reads at runtime.
+ * Reflector reads at runtime. The guard uses getAllAndOverride over both
+ * the handler and the class, so a class-level @Public() opens every
+ * mutation in that resolver; classes are checked for the same reason.
  */
 describe('Mutation Auth Architecture', () => {
   // Set by @Mutation() via addResolverMetadata (see @nestjs/graphql
@@ -63,6 +65,11 @@ describe('Mutation Auth Architecture', () => {
           continue;
         }
 
+        // ClerkAuthGuard checks class metadata too (getAllAndOverride), so a
+        // class-level @Public() makes every mutation in the resolver public.
+        const classIsPublic =
+          Reflect.getMetadata(IS_PUBLIC_KEY, exported) === true;
+
         for (const methodName of Object.getOwnPropertyNames(
           exported.prototype,
         )) {
@@ -83,10 +90,15 @@ describe('Mutation Auth Architecture', () => {
           }
           mutationsChecked++;
 
-          if (Reflect.getMetadata(IS_PUBLIC_KEY, handler) === true) {
+          if (
+            classIsPublic ||
+            Reflect.getMetadata(IS_PUBLIC_KEY, handler) === true
+          ) {
             violations.push({
               file: path.relative(modulesDir, file),
-              method: `${exported.name}.${methodName}`,
+              method: `${exported.name}.${methodName}${
+                classIsPublic ? ' (class-level @Public())' : ''
+              }`,
               mutation:
                 Reflect.getMetadata('graphql:resolver_name', handler) ??
                 methodName,

--- a/apps/soccer-stats/api/src/modules/game-events/game-events.resolver.ts
+++ b/apps/soccer-stats/api/src/modules/game-events/game-events.resolver.ts
@@ -119,7 +119,6 @@ export class GameEventsResolver {
   }
 
   @Mutation(() => Boolean, { name: 'removeFromLineup' })
-  @Public() // TODO: Add proper auth
   removeFromLineup(
     @Args('gameEventId', { type: () => ID }) gameEventId: string,
   ): Promise<boolean> {
@@ -127,7 +126,6 @@ export class GameEventsResolver {
   }
 
   @Mutation(() => GameEvent, { name: 'updatePlayerPosition' })
-  @Public() // TODO: Add proper auth
   updatePlayerPosition(
     @Args('gameEventId', { type: () => ID }) gameEventId: string,
     @Args('position') position: string,
@@ -175,7 +173,6 @@ export class GameEventsResolver {
   }
 
   @Mutation(() => Boolean, { name: 'deleteGoal' })
-  @Public() // TODO: Add proper auth
   deleteGoal(
     @Args('gameEventId', { type: () => ID }) gameEventId: string,
   ): Promise<boolean> {
@@ -183,7 +180,6 @@ export class GameEventsResolver {
   }
 
   @Mutation(() => Boolean, { name: 'deleteSubstitution' })
-  @Public() // TODO: Add proper auth
   deleteSubstitution(
     @Args('gameEventId', { type: () => ID }) gameEventId: string,
   ): Promise<boolean> {
@@ -191,7 +187,6 @@ export class GameEventsResolver {
   }
 
   @Mutation(() => Boolean, { name: 'deletePositionSwap' })
-  @Public() // TODO: Add proper auth
   deletePositionSwap(
     @Args('gameEventId', { type: () => ID }) gameEventId: string,
   ): Promise<boolean> {
@@ -199,7 +194,6 @@ export class GameEventsResolver {
   }
 
   @Mutation(() => Boolean, { name: 'deleteStarterEntry' })
-  @Public() // TODO: Add proper auth
   deleteStarterEntry(
     @Args('gameEventId', { type: () => ID }) gameEventId: string,
   ): Promise<boolean> {
@@ -207,7 +201,6 @@ export class GameEventsResolver {
   }
 
   @Mutation(() => GameEvent, { name: 'updateGoal' })
-  @Public() // TODO: Add proper auth
   updateGoal(@Args('input') input: UpdateGoalInput): Promise<GameEvent> {
     return this.gameEventsService.updateGoal(input);
   }
@@ -305,7 +298,6 @@ export class GameEventsResolver {
   }
 
   @Mutation(() => Boolean, { name: 'deleteEventWithCascade' })
-  @Public() // TODO: Add proper auth
   deleteEventWithCascade(
     @Args('gameEventId', { type: () => ID }) gameEventId: string,
     @Args('eventType') eventType: string,
@@ -330,7 +322,6 @@ export class GameEventsResolver {
   }
 
   @Mutation(() => GameEvent, { name: 'resolveEventConflict' })
-  @Public() // TODO: Add proper auth
   resolveEventConflict(
     @Args('conflictId', { type: () => ID }) conflictId: string,
     @Args('selectedEventId', { type: () => ID }) selectedEventId: string,

--- a/apps/soccer-stats/api/src/modules/game-formats/game-formats.resolver.ts
+++ b/apps/soccer-stats/api/src/modules/game-formats/game-formats.resolver.ts
@@ -26,15 +26,13 @@ export class GameFormatsResolver {
   }
 
   @Mutation(() => GameFormat)
-  @Public() // Temporarily public for MVP
   async createGameFormat(
-    @Args('input') input: CreateGameFormatInput
+    @Args('input') input: CreateGameFormatInput,
   ): Promise<GameFormat> {
     return this.gameFormatsService.create(input);
   }
 
   @Mutation(() => Boolean)
-  @Public() // Temporarily public for MVP
   async seedGameFormats(): Promise<boolean> {
     await this.gameFormatsService.seedDefaultFormats();
     return true;

--- a/apps/soccer-stats/api/src/modules/games/games.resolver.ts
+++ b/apps/soccer-stats/api/src/modules/games/games.resolver.ts
@@ -44,7 +44,6 @@ export class GamesResolver {
   }
 
   @Mutation(() => Game)
-  @Public() // TODO(#186): Restore auth guard after MVP
   async createGame(@Args('createGameInput') createGameInput: CreateGameInput) {
     this.logger.log(
       `Creating game with input: ${JSON.stringify(createGameInput)}`,
@@ -124,7 +123,6 @@ export class GamesResolver {
   @Mutation(() => GameTeam, {
     description: 'Update game team settings (formation, stats tracking level)',
   })
-  @Public() // TODO(#186): Restore auth guard after MVP
   async updateGameTeam(
     @Args('gameTeamId', { type: () => ID }) gameTeamId: string,
     @Args('updateGameTeamInput') updateGameTeamInput: UpdateGameTeamInput,


### PR DESCRIPTION
## Summary
- Removes `@Public()` from 13 mutations across `games`, `game-events`, and `game-formats` resolvers, so the class-level `ClerkAuthGuard` enforces authentication on every write operation
- Read queries and subscriptions remain public (spectator viewing is unaffected)
- Adds an architectural spec (`mutation-auth.architectural.spec.ts`) that loads every `*.resolver.ts` and fails if any `@Mutation()` handler carries `@Public()` metadata — the exact metadata the guard's Reflector reads — preventing regressions

## Context
The API is deployed publicly (App Runner + CloudFront). These mutations — including `deleteGoal`, `deleteEventWithCascade`, `createGame`, `updateGameTeam` — were callable by anyone without a token. The old TODOs pointed at #186, which is closed and unrelated; #285 now tracks this properly.

The UI already attaches Clerk Bearer tokens to all HTTP requests and WS connections and has a global `UNAUTHENTICATED` recovery flow, so signed-in users are unaffected. `seedGameFormats` is only invoked internally (migration/service), never via unauthenticated GraphQL.

Closes #285

## Verification
- `pnpm nx test soccer-stats-api --skip-nx-cache` — 20 suites, 225 tests pass
- Watched the new architectural spec fail first, listing exactly the 13 offenders, before removing the decorators (TDD)
- `pnpm nx lint soccer-stats-api` — 0 errors
- `pnpm nx build soccer-stats-api --skip-nx-cache` — success

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014AEbsiQHuMnoFoe8Wq1Hau