### PR TITLE
fix(soccer-stats-api): cap V8 heap and expose heap size limit in health

### DIFF
--- a/apps/soccer-stats/api/Dockerfile
+++ b/apps/soccer-stats/api/Dockerfile
@@ -18,6 +18,10 @@ ENV PORT=3333
 ENV APP_VERSION=${APP_VERSION}
 ENV GIT_SHA=${GIT_SHA}
 ENV BUILD_TIME=${BUILD_TIME}
+# Cap the V8 heap below the 512 MB App Runner instance memory so GC kicks in
+# before the container is OOM-killed. Node does not reliably derive this from
+# container limits on its own. Verify in prod via /api/health heapSizeLimitMB.
+ENV NODE_OPTIONS=--max-old-space-size=400
 
 # Enable corepack for pnpm
 RUN corepack enable && corepack prepare pnpm@latest --activate

--- a/apps/soccer-stats/api/src/app/app.service.spec.ts
+++ b/apps/soccer-stats/api/src/app/app.service.spec.ts
@@ -116,6 +116,7 @@ describe('AppService', () => {
       const result = createServiceWithMemory({
         heapUsedMB: 46,
         heapTotalMB: 50,
+        heapSizeLimitMB: 400,
         rssMB: 124,
         externalMB: 5,
       }).getHealth();
@@ -134,6 +135,7 @@ describe('AppService', () => {
       const result = createServiceWithMemory({
         heapUsedMB: 80,
         heapTotalMB: 120,
+        heapSizeLimitMB: 400,
         rssMB: 400,
         externalMB: 10,
       }).getHealth();
@@ -148,6 +150,7 @@ describe('AppService', () => {
       const result = createServiceWithMemory({
         heapUsedMB: 80,
         heapTotalMB: 120,
+        heapSizeLimitMB: 400,
         rssMB: 384,
         externalMB: 10,
       }).getHealth();
@@ -162,6 +165,7 @@ describe('AppService', () => {
       const result = createServiceWithMemory({
         heapUsedMB: 100,
         heapTotalMB: 120,
+        heapSizeLimitMB: 400,
         rssMB: 460.8,
         externalMB: 10,
       }).getHealth();
@@ -176,12 +180,27 @@ describe('AppService', () => {
       const result = createServiceWithMemory({
         heapUsedMB: 100,
         heapTotalMB: 120,
+        heapSizeLimitMB: 400,
         rssMB: 470,
         externalMB: 10,
       }).getHealth();
 
       expect(result.status).toBe('unhealthy');
       expect(result.memory?.rssUsagePercent).toBe(91.8);
+    });
+
+    it('exposes the V8 heap size limit in the memory metrics', () => {
+      process.env['CONTAINER_MEMORY_LIMIT_MB'] = '512';
+
+      const result = createServiceWithMemory({
+        heapUsedMB: 46,
+        heapTotalMB: 50,
+        heapSizeLimitMB: 400,
+        rssMB: 124,
+        externalMB: 5,
+      }).getHealth();
+
+      expect(result.memory?.heapSizeLimitMB).toBe(400);
     });
   });
 });

--- a/apps/soccer-stats/api/src/app/app.service.ts
+++ b/apps/soccer-stats/api/src/app/app.service.ts
@@ -11,6 +11,7 @@ import {
 export interface MemoryMetrics {
   heapUsedMB: number;
   heapTotalMB: number;
+  heapSizeLimitMB: number;
   rssMB: number;
   heapUsagePercent: number;
   containerLimitMB: number;
@@ -137,6 +138,7 @@ export class AppService {
       memory: {
         heapUsedMB: snapshot.heapUsedMB,
         heapTotalMB: snapshot.heapTotalMB,
+        heapSizeLimitMB: snapshot.heapSizeLimitMB,
         rssMB: snapshot.rssMB,
         heapUsagePercent,
         containerLimitMB: this.containerMemoryLimitMB,

--- a/apps/soccer-stats/api/src/modules/observability/observability.service.spec.ts
+++ b/apps/soccer-stats/api/src/modules/observability/observability.service.spec.ts
@@ -1,0 +1,30 @@
+import { ObservabilityService } from './observability.service';
+
+describe('ObservabilityService', () => {
+  let service: ObservabilityService;
+
+  beforeEach(() => {
+    service = new ObservabilityService();
+  });
+
+  describe('getMemorySnapshot', () => {
+    it('reports the V8 heap size limit so operators can verify --max-old-space-size took effect', () => {
+      const snapshot = service.getMemorySnapshot();
+
+      expect(snapshot.heapSizeLimitMB).toBeGreaterThan(0);
+      // The limit is the ceiling the heap can grow to, so it can never be
+      // below what is currently allocated.
+      expect(snapshot.heapSizeLimitMB).toBeGreaterThanOrEqual(
+        snapshot.heapTotalMB,
+      );
+    });
+
+    it('reports current usage in MB', () => {
+      const snapshot = service.getMemorySnapshot();
+
+      expect(snapshot.heapUsedMB).toBeGreaterThan(0);
+      expect(snapshot.heapTotalMB).toBeGreaterThanOrEqual(snapshot.heapUsedMB);
+      expect(snapshot.rssMB).toBeGreaterThan(0);
+    });
+  });
+});

--- a/apps/soccer-stats/api/src/modules/observability/observability.service.ts
+++ b/apps/soccer-stats/api/src/modules/observability/observability.service.ts
@@ -1,11 +1,15 @@
+import * as v8 from 'v8';
+
 import { Injectable, Logger } from '@nestjs/common';
 
 /**
- * Memory snapshot from process.memoryUsage()
+ * Memory snapshot from process.memoryUsage() and v8.getHeapStatistics()
  */
 export interface MemorySnapshot {
   readonly heapUsedMB: number;
   readonly heapTotalMB: number;
+  /** Max size the V8 heap can grow to (set by --max-old-space-size) */
+  readonly heapSizeLimitMB: number;
   readonly rssMB: number;
   readonly externalMB: number;
 }
@@ -46,12 +50,14 @@ export class ObservabilityService {
    */
   getMemorySnapshot(): MemorySnapshot {
     const usage = process.memoryUsage();
+    const heapStats = v8.getHeapStatistics();
     const bytesToMB = (bytes: number) =>
       Math.round((bytes / 1024 / 1024) * 100) / 100;
 
     return {
       heapUsedMB: bytesToMB(usage.heapUsed),
       heapTotalMB: bytesToMB(usage.heapTotal),
+      heapSizeLimitMB: bytesToMB(heapStats.heap_size_limit),
       rssMB: bytesToMB(usage.rss),
       externalMB: bytesToMB(usage.external),
     };

--- a/apps/soccer-stats/api/src/modules/observability/observability.service.ts
+++ b/apps/soccer-stats/api/src/modules/observability/observability.service.ts
@@ -8,7 +8,11 @@ import { Injectable, Logger } from '@nestjs/common';
 export interface MemorySnapshot {
   readonly heapUsedMB: number;
   readonly heapTotalMB: number;
-  /** Max size the V8 heap can grow to (set by --max-old-space-size) */
+  /**
+   * Max size the V8 heap can grow to. Influenced by --max-old-space-size
+   * but not equal to it: the limit also covers young-gen and other heap
+   * spaces, so expect a value somewhat above the flag.
+   */
   readonly heapSizeLimitMB: number;
   readonly rssMB: number;
   readonly externalMB: number;


### PR DESCRIPTION
## Summary
- Sets `NODE_OPTIONS=--max-old-space-size=400` in the API Docker image so V8 garbage-collects before the 512 MB App Runner instance is OOM-killed (Node does not reliably derive heap limits from container memory)
- Adds `heapSizeLimitMB` (from `v8.getHeapStatistics()`) to the observability memory snapshot and the `/api/health` response, so the cap can be verified in production
- Adds an `ObservabilityService` spec (there was none)

## Context
Supersedes the remaining useful pieces of draft PR #267. The core of issue #252 — the misleading `heapUsed/heapTotal` health gate — was already fixed on main (`76a10a8`, `cf58c22`) by gating on RSS vs. container limit, so #267's health-gate rewrite is obsolete and it will be closed in favor of this PR.

Closes #252

## Verification
- `pnpm nx test soccer-stats-api --skip-nx-cache` — 20 suites, 227 tests pass (new specs watched failing first)
- `pnpm nx build soccer-stats-api --skip-nx-cache` — success
- `pnpm nx lint soccer-stats-api` — 0 errors
- After deploy, `/api/health` should show `heapSizeLimitMB` ≈ 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014AEbsiQHuMnoFoe8Wq1Hau